### PR TITLE
fix: avoid UTF-8 panic when truncating chat errors

### DIFF
--- a/crates/skilllite-agent/src/chat.rs
+++ b/crates/skilllite-agent/src/chat.rs
@@ -238,8 +238,9 @@ pub fn run_agent_run(config: AgentConfig, goal: String, resume: bool) -> Result<
 /// this function just truncates overly long errors for terminal display.
 fn format_chat_error(e: &crate::Error) -> String {
     let s = e.to_string();
-    if s.len() > 300 {
-        format!("{}…", &s[..300])
+    let truncated: String = s.chars().take(300).collect();
+    if truncated.chars().count() < s.chars().count() {
+        format!("{truncated}…")
     } else {
         s
     }
@@ -324,4 +325,44 @@ async fn run_interactive_chat(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn format_chat_error_from_message(message: &str) -> String {
+        let err = crate::Error::validation(message.to_string());
+        format_chat_error(&err)
+    }
+
+    #[test]
+    fn format_chat_error_keeps_short_messages() {
+        let msg = "short message";
+        assert_eq!(format_chat_error_from_message(msg), msg);
+    }
+
+    #[test]
+    fn format_chat_error_truncates_long_ascii_without_panicking() {
+        let msg = "a".repeat(500);
+        let formatted = format_chat_error_from_message(&msg);
+        assert!(formatted.ends_with('…'));
+        assert_eq!(formatted.chars().count(), 301);
+    }
+
+    #[test]
+    fn format_chat_error_truncates_long_cjk_without_panicking() {
+        let msg = "你".repeat(500);
+        let formatted = format_chat_error_from_message(&msg);
+        assert!(formatted.ends_with('…'));
+        assert_eq!(formatted.chars().count(), 301);
+    }
+
+    #[test]
+    fn format_chat_error_truncates_long_emoji_without_panicking() {
+        let msg = "😀".repeat(500);
+        let formatted = format_chat_error_from_message(&msg);
+        assert!(formatted.ends_with('…'));
+        assert_eq!(formatted.chars().count(), 301);
+    }
 }


### PR DESCRIPTION
Use character-safe truncation in chat error formatting and add regression tests for ASCII, CJK, and emoji messages so long errors never panic on multibyte boundaries.

Made-with: Cursor

## Summary

- What problem does this PR solve?
- Why this approach?

## Task Linkage

- Task ID: `TASK-YYYY-NNN` (or `N/A` for lightweight external/community PRs)
- Task folder: `tasks/TASK-YYYY-NNN-.../` (optional in lightweight mode)

## Injected Specs

- [ ] `spec/architecture-boundaries.md` (if architecture/layering changed)
- [ ] `spec/security-nonnegotiables.md` (if sandbox/security changed)
- [ ] `spec/testing-policy.md` (required for any code change)
- [ ] `spec/docs-sync.md` (if behavior/docs/env/commands changed)

## Validation Evidence

- Commands executed:
  - `...`
- Key results:
  - `...`

## Regression Scope

- Areas likely affected:
  - `...`
- Explicit non-goals:
  - `...`

## Docs Sync (EN/ZH)

- [ ] Not needed
- [ ] Updated EN + ZH docs
- Files:
  - `...`

## Review Checklist

- [ ] Acceptance criteria in `tasks/.../TASK.md` satisfied (or explicitly deferred)
- [ ] `tasks/.../STATUS.md` updated with latest progress
- [ ] `tasks/.../REVIEW.md` includes merge readiness decision
- [ ] `tasks/board.md` status is up to date
