### PR TITLE
fix: wrap onboarding health check payload in input object

### DIFF
--- a/crates/skilllite-assistant/src/components/OnboardingModal.tsx
+++ b/crates/skilllite-assistant/src/components/OnboardingModal.tsx
@@ -285,9 +285,11 @@ export default function OnboardingModal() {
     setHealthResult(null);
     try {
       const result = await invoke<OnboardingHealthCheckResult>("skilllite_health_check", {
-        workspace: ws,
-        provider: mode,
-        apiKey: mode === "api" ? apiKey.trim() : undefined,
+        input: {
+          workspace: ws,
+          provider: mode,
+          apiKey: mode === "api" ? apiKey.trim() : undefined,
+        },
       });
       setHealthResult(result);
       if (result.ok) {


### PR DESCRIPTION
## Background
On desktop onboarding, clicking **Health Check** could fail immediately with:

- `invalid args input for command skilllite_health_check`
- `missing required key input`

Root cause: the frontend invoked `skilllite_health_check` with a flat payload, while the Tauri command signature expects a nested `input` object.

## Changes
- Update onboarding invoke payload in `crates/skilllite-assistant/src/components/OnboardingModal.tsx`.
- Change from flat payload:
  - `workspace`
  - `provider`
  - `apiKey`
- To nested payload:
  - `input.workspace`
  - `input.provider`
  - `input.apiKey`

This aligns the webview request shape with Rust command signature:
- `skilllite_health_check(app, input: OnboardingHealthCheckInput)`

## Repro Steps (Before)
1. Open desktop app and enter onboarding flow.
2. Choose API mode and fill model/key/workspace.
3. Click **Health Check**.
4. Observe immediate error: `missing required key input`.

## Verification (After)
1. Repeat onboarding flow and click **Health Check**.
2. Confirm command is accepted (no missing `input` arg error).
3. Health check proceeds to provider/workspace checks.

## Test Plan
- [x] Rust test (input parsing compatibility):
  - `cargo test --manifest-path crates/skilllite-assistant/src-tauri/Cargo.toml onboarding_health_check_input_tests -- --nocapture`
- [x] Manual desktop validation:
  - onboarding health check no longer throws `missing required key input`.

## Screenshots
- N/A for this fix (payload-shape compatibility change only).
- If needed, can add before/after onboarding error screenshots in follow-up.

## Risk Assessment
- **Scope:** Low, single frontend call-site change.
- **Behavioral risk:** Low. Only request envelope shape changed; business logic unchanged.
- **Compatibility:** Preserves existing backend field handling (`apiKey` plus legacy alias support at Rust layer).

## Rollback Plan
- Revert commit `7a1e240` from this PR branch.
- If rollback is needed quickly, cherry-pick revert onto release branch and redeploy desktop build.