### PR TITLE
feat(assistant): evolution L2 CLI bridge and faster tauri dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ MIT — See [THIRD_PARTY_LICENSES.md](./THIRD_PARTY_LICENSES.md) for third-party
 ## 📚 Documentation
 
 - [Pick your path](./docs/en/START_PATHS.md) — Sandbox/MCP (recommended) vs full stack vs optional desktop
+- [Assistant split architecture](./docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md) — How the desktop app can live in its own repo (L1/L2/L3, migration phases)
 - [Getting Started](./docs/en/GETTING_STARTED.md) — Installation and quick start guide
 - [Channel and Gateway](./docs/en/GUIDE_CHANNEL_GATEWAY.md) — Inbound webhook, `SKILLLITE_CHANNEL_*`, Assistant (EN); [中文](./docs/zh/GUIDE_CHANNEL_GATEWAY.md)
 - [Changelog](./CHANGELOG.md) — Version history and upgrade notes

--- a/crates/skilllite-assistant/README.md
+++ b/crates/skilllite-assistant/README.md
@@ -2,6 +2,10 @@
 
 Tauri 2 + React 18 + TypeScript + Vite 桌面应用脚手架。
 
+**可选官方 GUI** — 默认推荐路径是 `pip install skilllite` + MCP（见仓库根 README）。本应用是引擎的图形分发渠道。
+
+**拆仓架构（目标态）：** 聊天走 `skilllite agent-rpc`（L1）；进化/运行时等逐步改为 `skilllite … --json`（L2），最终不再 path 依赖 `skilllite-agent` / `skilllite-evolution` / `skilllite-sandbox`。详见 [Assistant split architecture](../../docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md)（[中文](../../docs/zh/ASSISTANT-SPLIT-ARCHITECTURE.md)）。
+
 **所有 npm 命令必须在当前目录（`crates/skilllite-assistant`）下执行**，仓库根目录没有 `package.json`。
 
 ## Vite 配置
@@ -16,16 +20,31 @@ Tauri 2 + React 18 + TypeScript + Vite 桌面应用脚手架。
 ```bash
 cd crates/skilllite-assistant   # 若在仓库根目录，先执行这句
 npm install
+npm run prebuild:tauri          # 首次或改引擎后：安装 ~/.skilllite/bin/skilllite（可选但推荐）
 npm run tauri dev
 ```
+
+`tauri dev` 的 `beforeDevCommand` **只启动 Vite**（`scripts/dev-tauri.sh`），不会在每次开发前跑完整的 `prebuild-skilllite.sh`（其中 `cargo install --release` 常需数分钟）。若仍把完整预构建串在 `beforeDevCommand` 里，Tauri 会在约 **180 秒** 内等不到 `http://localhost:5173` 并报错，而 `cargo install` 可能仍在后台继续。
+
+- 需要打包资源或强制重装引擎：`npm run prebuild:tauri`
+- 开发时后台刷新引擎：`SKILLLITE_BACKGROUND_PREBUILD=1 npm run tauri dev`（日志 `/tmp/skilllite-prebuild-dev.log`）
+- 已有 `~/.skilllite/bin/skilllite` 且不想碰引擎：直接 `npm run tauri dev`
+
+### 无法连接 localhost:5173（等待 180s 超时）
+
+1. 确认在 **`crates/skilllite-assistant`** 下执行，且已 `npm install`。
+2. 另开终端试：`npm run dev`，浏览器打开 http://localhost:5173 是否正常。
+3. 若 Vite 能起、仅 `tauri dev` 失败：检查 `tauri.conf.json` 的 `devUrl` 与 `vite.config.ts` 的 `port` 是否同为 **5173**（勿只改一端）。
+4. 若刚改过 Rust 引擎：先 `npm run prebuild:tauri` 或等后台安装完成，并保证 `export PATH="$HOME/.skilllite/bin:$PATH"`。
 
 ### 端口 5173 已被占用
 
 开发服务器固定使用 **5173**（与 `src-tauri/tauri.conf.json` 里的 `devUrl` 一致），且 `vite.config.ts` 里为 **`strictPort: true`**，被占用时会直接报错：`Port 5173 is already in use`。
 
 1. 查看占用进程：`lsof -nP -iTCP:5173 -sTCP:LISTEN`
-2. 若确认可结束（例如上次未关干净的 Vite / 另一个前端项目），例如：`kill <PID>`  
-   本机曾出现示例：`node` 监听 `[::1]:5173`。
+2. 若确认可结束（例如上次未关干净的 Vite / 另一个前端项目）：`kill $(lsof -t -iTCP:5173 -sTCP:LISTEN)`  
+   本机常见为 `node` 监听 `[::1]:5173`。
+3. 若该进程**就是本项目的 Vite** 且页面能打开，可直接再跑 `npm run tauri dev`：`dev-tauri.sh` 会**复用**已在跑的 dev server（无需再起第二个 Vite）。
 
 若你**需要同时**跑两个 Vite 项目，不要只改 `vite.config.ts` 端口而不改 Tauri 的 `devUrl`，否则桌面壳仍连旧地址；应成对修改 `vite.config.ts` 的 `server.port` 与 `tauri.conf.json` 的 `build.devUrl`。
 

--- a/crates/skilllite-assistant/scripts/dev-tauri.sh
+++ b/crates/skilllite-assistant/scripts/dev-tauri.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Start Vite immediately for `tauri dev`. Full release prebuild is NOT run here
+# (it can take several minutes and exceeds Tauri's ~180s dev-server wait).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ASSISTANT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BIN_DIR="${HOME}/.skilllite/bin"
+SKILLLITE_BIN="${BIN_DIR}/skilllite"
+
+if [[ "${SKILLLITE_SKIP_PREBUILD:-}" != "1" ]]; then
+  if [[ ! -x "${SKILLLITE_BIN}" ]]; then
+    echo "dev: ${SKILLLITE_BIN} not found — installing in background (log: /tmp/skilllite-prebuild-dev.log)"
+    echo "dev: chat/agent features need PATH to include ~/.skilllite/bin until install finishes."
+    bash "${SCRIPT_DIR}/prebuild-skilllite-dev.sh" >>/tmp/skilllite-prebuild-dev.log 2>&1 &
+  elif [[ "${SKILLLITE_BACKGROUND_PREBUILD:-}" == "1" ]]; then
+    echo "dev: refreshing skilllite in background (log: /tmp/skilllite-prebuild-dev.log)"
+    SKILLLITE_FORCE_PREBUILD=1 bash "${SCRIPT_DIR}/prebuild-skilllite-dev.sh" >>/tmp/skilllite-prebuild-dev.log 2>&1 &
+  fi
+fi
+
+DEV_URL="${TAURI_DEV_URL:-http://localhost:5173}"
+
+port_in_use() {
+  lsof -nP -iTCP:5173 -sTCP:LISTEN >/dev/null 2>&1
+}
+
+dev_server_up() {
+  curl -sf --max-time 2 "${DEV_URL}/" >/dev/null 2>&1
+}
+
+cd "${ASSISTANT_DIR}"
+
+if dev_server_up; then
+  echo "dev: reusing existing Vite at ${DEV_URL} (to restart: kill \$(lsof -t -iTCP:5173 -sTCP:LISTEN))"
+  # Keep beforeDevCommand alive so Tauri does not treat the hook as crashed.
+  exec tail -f /dev/null
+fi
+
+if port_in_use; then
+  echo "error: port 5173 is in use but ${DEV_URL} did not respond." >&2
+  echo "       Another process may be stuck. Inspect:" >&2
+  lsof -nP -iTCP:5173 -sTCP:LISTEN >&2 || true
+  echo "       Free the port, e.g.: kill \$(lsof -t -iTCP:5173 -sTCP:LISTEN)" >&2
+  exit 1
+fi
+
+exec npm run dev

--- a/crates/skilllite-assistant/scripts/prebuild-skilllite-dev.sh
+++ b/crates/skilllite-assistant/scripts/prebuild-skilllite-dev.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Dev-only: install skilllite to ~/.skilllite/bin when missing or forced.
+# Skips bundling into src-tauri/resources (production prebuild does that).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ASSISTANT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT="$(cd "$ASSISTANT_DIR/../.." && pwd)"
+BIN_DIR="${HOME}/.skilllite/bin"
+SKILLLITE_BIN="${BIN_DIR}/skilllite"
+
+if [[ -x "${SKILLLITE_BIN}" && "${SKILLLITE_FORCE_PREBUILD:-}" != "1" ]]; then
+  echo "dev prebuild: using ${SKILLLITE_BIN} (set SKILLLITE_FORCE_PREBUILD=1 to reinstall)"
+  exit 0
+fi
+
+cd "$ROOT"
+mkdir -p "${BIN_DIR}"
+rm -f "${SKILLLITE_BIN}"
+cargo install --path skilllite --features memory_vector --root "${HOME}/.skilllite" --force
+echo "dev prebuild: installed ${SKILLLITE_BIN}"

--- a/crates/skilllite-assistant/src-tauri/src/commands/evolution.rs
+++ b/crates/skilllite-assistant/src-tauri/src/commands/evolution.rs
@@ -2,6 +2,7 @@
 
 #[tauri::command]
 pub async fn skilllite_load_evolution_status(
+    app: tauri::AppHandle,
     workspace: Option<String>,
     config: Option<crate::skilllite_bridge::ChatConfigOverrides>,
     life_pulse: tauri::State<'_, crate::life_pulse::LifePulseState>,
@@ -11,8 +12,14 @@ pub async fn skilllite_load_evolution_status(
 > {
     let ws = workspace.unwrap_or_else(|| ".".to_string());
     let periodic_anchor_unix = life_pulse.periodic_anchor_unix();
+    let skilllite_path = crate::skilllite_bridge::resolve_skilllite_path_app(&app);
     let out = match tauri::async_runtime::spawn_blocking(move || {
-        crate::skilllite_bridge::load_evolution_status(&ws, config, periodic_anchor_unix)
+        crate::skilllite_bridge::load_evolution_status(
+            &ws,
+            config,
+            periodic_anchor_unix,
+            Some(&skilllite_path),
+        )
     })
     .await
     {
@@ -26,11 +33,13 @@ pub async fn skilllite_load_evolution_status(
 
 #[tauri::command]
 pub async fn skilllite_list_evolution_pending(
+    app: tauri::AppHandle,
     workspace: Option<String>,
 ) -> Vec<crate::skilllite_bridge::PendingSkillDto> {
     let ws = workspace.unwrap_or_else(|| ".".to_string());
+    let skilllite_path = crate::skilllite_bridge::resolve_skilllite_path_app(&app);
     tauri::async_runtime::spawn_blocking(move || {
-        crate::skilllite_bridge::list_evolution_pending_skills(&ws)
+        crate::skilllite_bridge::list_evolution_pending_skills(&ws, Some(&skilllite_path))
     })
     .await
     .unwrap_or_default()
@@ -51,12 +60,18 @@ pub async fn skilllite_read_pending_skill_md(
 
 #[tauri::command]
 pub async fn skilllite_confirm_pending_skill(
+    app: tauri::AppHandle,
     workspace: Option<String>,
     skill_name: String,
 ) -> Result<(), String> {
     let ws = workspace.unwrap_or_else(|| ".".to_string());
+    let skilllite_path = crate::skilllite_bridge::resolve_skilllite_path_app(&app);
     tauri::async_runtime::spawn_blocking(move || {
-        crate::skilllite_bridge::evolution_confirm_pending_skill(&ws, &skill_name)
+        crate::skilllite_bridge::evolution_confirm_pending_skill(
+            &ws,
+            &skill_name,
+            Some(&skilllite_path),
+        )
     })
     .await
     .map_err(|e| e.to_string())?
@@ -64,12 +79,18 @@ pub async fn skilllite_confirm_pending_skill(
 
 #[tauri::command]
 pub async fn skilllite_reject_pending_skill(
+    app: tauri::AppHandle,
     workspace: Option<String>,
     skill_name: String,
 ) -> Result<(), String> {
     let ws = workspace.unwrap_or_else(|| ".".to_string());
+    let skilllite_path = crate::skilllite_bridge::resolve_skilllite_path_app(&app);
     tauri::async_runtime::spawn_blocking(move || {
-        crate::skilllite_bridge::evolution_reject_pending_skill(&ws, &skill_name)
+        crate::skilllite_bridge::evolution_reject_pending_skill(
+            &ws,
+            &skill_name,
+            Some(&skilllite_path),
+        )
     })
     .await
     .map_err(|e| e.to_string())?
@@ -100,12 +121,18 @@ pub async fn skilllite_authorize_capability_evolution(
 
 #[tauri::command]
 pub async fn skilllite_get_evolution_proposal_status(
+    app: tauri::AppHandle,
     workspace: Option<String>,
     proposal_id: String,
 ) -> Result<crate::skilllite_bridge::EvolutionProposalStatusDto, String> {
     let ws = workspace.unwrap_or_else(|| ".".to_string());
+    let skilllite_path = crate::skilllite_bridge::resolve_skilllite_path_app(&app);
     tauri::async_runtime::spawn_blocking(move || {
-        crate::skilllite_bridge::get_evolution_proposal_status(&ws, &proposal_id)
+        crate::skilllite_bridge::get_evolution_proposal_status(
+            &ws,
+            &proposal_id,
+            Some(&skilllite_path),
+        )
     })
     .await
     .map_err(|e| e.to_string())?
@@ -113,13 +140,15 @@ pub async fn skilllite_get_evolution_proposal_status(
 
 #[tauri::command]
 pub async fn skilllite_load_evolution_backlog(
+    app: tauri::AppHandle,
     workspace: Option<String>,
     limit: Option<u32>,
 ) -> Result<Vec<crate::skilllite_bridge::EvolutionBacklogRowDto>, String> {
     let ws = workspace.unwrap_or_else(|| ".".to_string());
     let capped = limit.unwrap_or(30) as usize;
+    let skilllite_path = crate::skilllite_bridge::resolve_skilllite_path_app(&app);
     tauri::async_runtime::spawn_blocking(move || {
-        crate::skilllite_bridge::load_evolution_backlog(&ws, capped)
+        crate::skilllite_bridge::load_evolution_backlog(&ws, capped, Some(&skilllite_path))
     })
     .await
     .map_err(|e| e.to_string())?

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/evolution_cli.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/evolution_cli.rs
@@ -1,0 +1,56 @@
+//! Spawn `skilllite` CLI with workspace env merge (L2 bridge for desktop evolution UI).
+
+use std::path::Path;
+use std::process::Command;
+
+use serde::de::DeserializeOwned;
+
+use super::chat::{merge_dotenv_with_chat_overrides, ChatConfigOverrides};
+use super::paths::{find_project_root, load_dotenv_for_child};
+
+pub fn spawn_skilllite(
+    skilllite_path: &Path,
+    workspace: &str,
+    cfg: Option<&ChatConfigOverrides>,
+    args: &[&str],
+) -> Result<std::process::Output, String> {
+    let root = find_project_root(workspace);
+    let mut cmd = Command::new(skilllite_path);
+    crate::windows_spawn::hide_child_console(&mut cmd);
+    cmd.args(args);
+    let env_pairs = merge_dotenv_with_chat_overrides(load_dotenv_for_child(workspace), cfg);
+    for (k, v) in env_pairs {
+        cmd.env(k, v);
+    }
+    cmd.current_dir(&root)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    cmd.output()
+        .map_err(|e| format!("spawn skilllite {}: {}", args.join(" "), e))
+}
+
+pub fn spawn_skilllite_json<T: DeserializeOwned>(
+    skilllite_path: &Path,
+    workspace: &str,
+    cfg: Option<&ChatConfigOverrides>,
+    args: &[&str],
+) -> Result<T, String> {
+    let output = spawn_skilllite(skilllite_path, workspace, cfg, args)?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "skilllite {} failed (exit {:?}): {}",
+            args.join(" "),
+            output.status.code(),
+            stderr.trim()
+        ));
+    }
+    serde_json::from_slice(&output.stdout).map_err(|e| {
+        format!(
+            "parse skilllite {} JSON: {} (stdout len={})",
+            args.join(" "),
+            e,
+            output.stdout.len()
+        )
+    })
+}

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/backlog.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/backlog.rs
@@ -1,8 +1,13 @@
-//! Evolution backlog rows and proposal status for the desktop UI.
+//! Evolution backlog rows and proposal status for the desktop UI (L2 CLI first).
 
-use serde::Serialize;
+use std::path::Path;
 
-#[derive(Debug, Clone, Serialize)]
+use serde::{Deserialize, Serialize};
+
+use crate::skilllite_bridge::chat::ChatConfigOverrides;
+use crate::skilllite_bridge::evolution_cli::spawn_skilllite_json;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvolutionProposalStatusDto {
     pub proposal_id: String,
     pub status: String,
@@ -12,7 +17,29 @@ pub struct EvolutionProposalStatusDto {
 }
 
 pub fn get_evolution_proposal_status(
-    _workspace: &str,
+    workspace: &str,
+    proposal_id: &str,
+    skilllite_path: Option<&Path>,
+) -> Result<EvolutionProposalStatusDto, String> {
+    if let Some(path) = skilllite_path {
+        if let Ok(row) = spawn_skilllite_json(
+            path,
+            workspace,
+            None,
+            &[
+                "evolution",
+                "proposal-status",
+                "--json",
+                proposal_id,
+            ],
+        ) {
+            return Ok(row);
+        }
+    }
+    get_evolution_proposal_status_inprocess(proposal_id)
+}
+
+fn get_evolution_proposal_status_inprocess(
     proposal_id: &str,
 ) -> Result<EvolutionProposalStatusDto, String> {
     let chat_root = skilllite_core::paths::chat_root();
@@ -37,7 +64,7 @@ pub fn get_evolution_proposal_status(
     .map_err(|e| e.to_string())
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvolutionBacklogRowDto {
     pub proposal_id: String,
     pub source: String,
@@ -50,9 +77,34 @@ pub struct EvolutionBacklogRowDto {
 }
 
 pub fn load_evolution_backlog(
-    _workspace: &str,
+    workspace: &str,
     limit: usize,
+    skilllite_path: Option<&Path>,
 ) -> Result<Vec<EvolutionBacklogRowDto>, String> {
+    if let Some(path) = skilllite_path {
+        let capped = limit.clamp(1, 200);
+        if let Ok(rows) = spawn_skilllite_json::<Vec<EvolutionBacklogRowDto>>(
+            path,
+            workspace,
+            None,
+            &[
+                "evolution",
+                "backlog",
+                "--json",
+                "--hide-closed",
+                "--limit",
+                &capped.to_string(),
+                "--workspace",
+                workspace,
+            ],
+        ) {
+            return Ok(rows);
+        }
+    }
+    load_evolution_backlog_inprocess(limit)
+}
+
+fn load_evolution_backlog_inprocess(limit: usize) -> Result<Vec<EvolutionBacklogRowDto>, String> {
     let chat_root = skilllite_core::paths::chat_root();
     let conn =
         skilllite_evolution::feedback::open_evolution_db(&chat_root).map_err(|e| e.to_string())?;

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/backlog.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/backlog.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::skilllite_bridge::chat::ChatConfigOverrides;
 use crate::skilllite_bridge::evolution_cli::spawn_skilllite_json;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/mod.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/mod.rs
@@ -1,7 +1,7 @@
 //! 进化反馈库、生长调度、待审核技能与 `run_evolution` / 后台 `evolution run` 触发（桌面 UI 数据源）。
 //!
 //! 子模块：`config`（合并后的环境与阈值）、`growth`（Life Pulse）、`status`（状态载荷）、
-//! `pending`（待审核技能）、`authorize`（能力进化授权）、`backlog`（队列行）、`trigger`（进程内 run）。
+//! `pending`（待审核技能）、`authorize`（能力进化授权）、`backlog`（队列行）、`trigger`（CLI run）。
 
 mod authorize;
 mod backlog;

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/pending.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/pending.rs
@@ -1,30 +1,46 @@
-//! Pending evolved skills: list, read, confirm, reject.
+//! Pending evolved skills: list, read, confirm, reject (L2 CLI first).
 
-use serde::Serialize;
+use std::path::Path;
 
+use serde::{Deserialize, Serialize};
+
+use crate::skilllite_bridge::evolution_cli::spawn_skilllite_json;
 use crate::skilllite_bridge::integrations::shared::{
     existing_workspace_skills_root, resolve_workspace_skills_root,
 };
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingSkillDto {
     pub name: String,
     pub needs_review: bool,
     pub preview: String,
 }
 
-fn truncate_utf8(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        return s.to_string();
-    }
-    let mut end = max;
-    while !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    format!("{}…", &s[..end])
+#[derive(Debug, Clone, Deserialize)]
+struct EvolutionOpDto {
+    ok: bool,
+    #[allow(dead_code)]
+    message: Option<String>,
 }
 
-pub fn list_evolution_pending_skills(workspace: &str) -> Vec<PendingSkillDto> {
+pub fn list_evolution_pending_skills(
+    workspace: &str,
+    skilllite_path: Option<&Path>,
+) -> Vec<PendingSkillDto> {
+    if let Some(path) = skilllite_path {
+        if let Ok(rows) = spawn_skilllite_json::<Vec<PendingSkillDto>>(
+            path,
+            workspace,
+            None,
+            &["evolution", "pending", "--json", "--workspace", workspace],
+        ) {
+            return rows;
+        }
+    }
+    list_evolution_pending_skills_inprocess(workspace)
+}
+
+fn list_evolution_pending_skills_inprocess(workspace: &str) -> Vec<PendingSkillDto> {
     let Some(skills_root) = existing_workspace_skills_root(workspace) else {
         return Vec::new();
     };
@@ -48,6 +64,17 @@ pub fn list_evolution_pending_skills(workspace: &str) -> Vec<PendingSkillDto> {
         .collect()
 }
 
+fn truncate_utf8(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &s[..end])
+}
+
 pub fn read_evolution_pending_skill_md(
     workspace: &str,
     skill_name: &str,
@@ -64,7 +91,35 @@ pub fn read_evolution_pending_skill_md(
     std::fs::read_to_string(&path).map_err(|e| e.to_string())
 }
 
-pub fn evolution_confirm_pending_skill(workspace: &str, skill_name: &str) -> Result<(), String> {
+pub fn evolution_confirm_pending_skill(
+    workspace: &str,
+    skill_name: &str,
+    skilllite_path: Option<&Path>,
+) -> Result<(), String> {
+    if let Some(path) = skilllite_path {
+        if let Ok(_op) = spawn_skilllite_json::<EvolutionOpDto>(
+            path,
+            workspace,
+            None,
+            &[
+                "evolution",
+                "confirm",
+                "--json",
+                "--workspace",
+                workspace,
+                skill_name,
+            ],
+        ) {
+            return Ok(());
+        }
+    }
+    evolution_confirm_pending_skill_inprocess(workspace, skill_name)
+}
+
+fn evolution_confirm_pending_skill_inprocess(
+    workspace: &str,
+    skill_name: &str,
+) -> Result<(), String> {
     let skills_root = resolve_workspace_skills_root(workspace);
     skilllite_evolution::skill_synth::confirm_pending_skill(&skills_root, skill_name)
         .map_err(|e| e.to_string())?;
@@ -82,7 +137,35 @@ pub fn evolution_confirm_pending_skill(workspace: &str, skill_name: &str) -> Res
     Ok(())
 }
 
-pub fn evolution_reject_pending_skill(workspace: &str, skill_name: &str) -> Result<(), String> {
+pub fn evolution_reject_pending_skill(
+    workspace: &str,
+    skill_name: &str,
+    skilllite_path: Option<&Path>,
+) -> Result<(), String> {
+    if let Some(path) = skilllite_path {
+        if let Ok(_op) = spawn_skilllite_json::<EvolutionOpDto>(
+            path,
+            workspace,
+            None,
+            &[
+                "evolution",
+                "reject",
+                "--json",
+                "--workspace",
+                workspace,
+                skill_name,
+            ],
+        ) {
+            return Ok(());
+        }
+    }
+    evolution_reject_pending_skill_inprocess(workspace, skill_name)
+}
+
+fn evolution_reject_pending_skill_inprocess(
+    workspace: &str,
+    skill_name: &str,
+) -> Result<(), String> {
     let skills_root = resolve_workspace_skills_root(workspace);
     skilllite_evolution::skill_synth::reject_pending_skill(&skills_root, skill_name)
         .map_err(|e| e.to_string())

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/pending.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/pending.rs
@@ -18,6 +18,7 @@ pub struct PendingSkillDto {
 
 #[derive(Debug, Clone, Deserialize)]
 struct EvolutionOpDto {
+    #[allow(dead_code)]
     ok: bool,
     #[allow(dead_code)]
     message: Option<String>,

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/status.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/status.rs
@@ -1,8 +1,14 @@
 //! Evolution feedback DB snapshot for the assistant UI (`load_evolution_status`).
+//!
+//! Prefer L2 `skilllite evolution status --json` when a `skilllite` binary is available; falls back to
+//! in-process engine crates if the CLI fails (older binary, spawn error).
 
-use serde::Serialize;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
 
 use crate::skilllite_bridge::chat::ChatConfigOverrides;
+use crate::skilllite_bridge::evolution_cli::spawn_skilllite_json;
 
 use super::config::{
     effective_evo_cooldown_hours, effective_evo_profile_key, evolution_mode_from_workspace,
@@ -10,7 +16,7 @@ use super::config::{
 };
 use crate::skilllite_bridge::integrations::shared::existing_workspace_skills_root;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvolutionLogEntryDto {
     pub ts: String,
     #[serde(rename = "event_type")]
@@ -22,7 +28,7 @@ pub struct EvolutionLogEntryDto {
     pub txn_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EvolutionStatusPayload {
     pub mode_key: String,
     pub mode_label: String,
@@ -59,11 +65,23 @@ pub struct EvolutionStatusPayload {
     pub db_error: Option<String>,
 }
 
-/// Evolution feedback DB + schedule hints for the assistant UI.
-///
-/// `periodic_anchor_unix`: last time the desktop **periodic** arm advanced (`LifePulseState`); pass
-/// `None` when unavailable (e.g. first launch — periodic elapsed is reported from “now”).
-pub fn load_evolution_status(
+fn load_evolution_status_via_cli(
+    workspace: &str,
+    cfg: Option<&ChatConfigOverrides>,
+    periodic_anchor_unix: Option<i64>,
+    skilllite_path: &Path,
+) -> Result<EvolutionStatusPayload, String> {
+    let mut args = vec!["evolution", "status", "--json", "--workspace", workspace];
+    let anchor_buf;
+    if let Some(anchor) = periodic_anchor_unix {
+        anchor_buf = anchor.to_string();
+        args.push("--periodic-anchor-unix");
+        args.push(&anchor_buf);
+    }
+    spawn_skilllite_json(skilllite_path, workspace, cfg, &args)
+}
+
+fn load_evolution_status_inprocess(
     workspace: &str,
     cfg: Option<ChatConfigOverrides>,
     periodic_anchor_unix: Option<i64>,
@@ -210,4 +228,26 @@ pub fn load_evolution_status(
         empty_proposals_reason,
         db_error,
     }
+}
+
+/// Evolution feedback DB + schedule hints for the assistant UI.
+///
+/// `periodic_anchor_unix`: last time the desktop **periodic** arm advanced (`LifePulseState`); pass
+/// `None` when unavailable (e.g. first launch — periodic elapsed is reported from “now”).
+///
+/// When `skilllite_path` is provided, tries `skilllite evolution status --json` first (L2).
+pub fn load_evolution_status(
+    workspace: &str,
+    cfg: Option<ChatConfigOverrides>,
+    periodic_anchor_unix: Option<i64>,
+    skilllite_path: Option<&Path>,
+) -> EvolutionStatusPayload {
+    if let Some(path) = skilllite_path {
+        if let Ok(payload) =
+            load_evolution_status_via_cli(workspace, cfg.as_ref(), periodic_anchor_unix, path)
+        {
+            return payload;
+        }
+    }
+    load_evolution_status_inprocess(workspace, cfg, periodic_anchor_unix)
 }

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/trigger.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/evolution_ui/trigger.rs
@@ -1,177 +1,29 @@
-//! In-process `run_evolution` for manual UI trigger.
+//! Manual evolution trigger via `skilllite evolution run --json` (L2).
 
-use crate::skilllite_bridge::chat::{merge_dotenv_with_chat_overrides, ChatConfigOverrides};
-use crate::skilllite_bridge::integrations::shared::existing_workspace_skills_root;
-use crate::skilllite_bridge::paths::load_dotenv_for_child;
+use skilllite_core::protocol::NodeResult;
 
-use super::config::EvolutionRunEnvGuard;
+use crate::skilllite_bridge::chat::ChatConfigOverrides;
+use crate::skilllite_bridge::evolution_cli::spawn_skilllite_json;
 
 pub fn trigger_evolution_run(
     workspace: &str,
     proposal_id: Option<&str>,
-    _skilllite_path: &std::path::Path,
+    skilllite_path: &std::path::Path,
     overrides: Option<ChatConfigOverrides>,
 ) -> Result<String, String> {
-    fn env_first_non_empty(
-        vars: &std::collections::HashMap<String, String>,
-        keys: &[&str],
-    ) -> Option<String> {
-        for k in keys {
-            if let Some(v) = vars.get(*k) {
-                let t = v.trim();
-                if !t.is_empty() {
-                    return Some(t.to_string());
-                }
-            }
-        }
-        None
+    let mut args: Vec<String> = vec![
+        "evolution".into(),
+        "run".into(),
+        "--json".into(),
+        "--log-manual-trigger".into(),
+        "--workspace".into(),
+        workspace.to_string(),
+    ];
+    if let Some(pid) = proposal_id.filter(|s| !s.trim().is_empty()) {
+        args.push("--proposal-id".into());
+        args.push(pid.to_string());
     }
-
-    use skilllite_core::config::env_keys::llm as llm_keys;
-    let env_map: std::collections::HashMap<String, String> =
-        load_dotenv_for_child(workspace).into_iter().collect();
-    let api_base_keys: Vec<&str> = std::iter::once(llm_keys::API_BASE)
-        .chain(llm_keys::API_BASE_ALIASES.iter().copied())
-        .collect();
-    let api_key_keys: Vec<&str> = std::iter::once(llm_keys::API_KEY)
-        .chain(llm_keys::API_KEY_ALIASES.iter().copied())
-        .collect();
-    let model_keys: Vec<&str> = std::iter::once(llm_keys::MODEL)
-        .chain(llm_keys::MODEL_ALIASES.iter().copied())
-        .collect();
-    let mut api_base = env_first_non_empty(&env_map, &api_base_keys)
-        .or_else(|| skilllite_core::config::LlmConfig::try_from_env().map(|c| c.api_base))
-        .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
-    let mut api_key = env_first_non_empty(&env_map, &api_key_keys)
-        .or_else(|| skilllite_core::config::LlmConfig::try_from_env().map(|c| c.api_key))
-        .unwrap_or_default();
-    let mut model = env_first_non_empty(&env_map, &model_keys)
-        .or_else(|| skilllite_core::config::LlmConfig::try_from_env().map(|c| c.model))
-        .unwrap_or_else(|| "gpt-4o".to_string());
-
-    // Match chat: keys/base/model from Settings are not written to process env; merge here so
-    // manual evolution trigger works when the user only configured the assistant UI.
-    if let Some(ref cfg) = overrides {
-        if let Some(ref b) = cfg.api_base {
-            if !b.trim().is_empty() {
-                api_base = b.clone();
-            }
-        }
-        if let Some(ref k) = cfg.api_key {
-            if !k.trim().is_empty() {
-                api_key = k.clone();
-            }
-        }
-        if let Some(ref m) = cfg.model {
-            if !m.trim().is_empty() {
-                model = m.clone();
-            }
-        }
-    }
-
-    if api_key.trim().is_empty() {
-        return Err(
-            "执行 evolution run 失败: 缺少 API key（请配置 SKILLLITE_API_KEY 或 OPENAI_API_KEY）"
-                .to_string(),
-        );
-    }
-
-    let dotenv = load_dotenv_for_child(workspace);
-    let merged_vec = merge_dotenv_with_chat_overrides(dotenv, overrides.as_ref());
-    let merged_map: std::collections::HashMap<String, String> = merged_vec.into_iter().collect();
-    let _evo_env_guard = EvolutionRunEnvGuard::push_from_merged(&merged_map);
-
-    let llm = skilllite_agent::llm::LlmClient::new(&api_base, &api_key)
-        .map_err(|e| format!("执行 evolution run 失败: 初始化 LLM 客户端失败: {}", e))?;
-    let adapter = skilllite_agent::evolution::EvolutionLlmAdapter { llm: &llm };
-    let skills_root = existing_workspace_skills_root(workspace);
-
-    let force_key = skilllite_core::config::env_keys::evolution::SKILLLITE_EVO_FORCE_PROPOSAL_ID;
-    let prev_force = std::env::var(force_key).ok();
-    match proposal_id {
-        Some(pid) => std::env::set_var(force_key, pid),
-        None => std::env::remove_var(force_key),
-    }
-    let run_result = tokio::runtime::Runtime::new()
-        .map_err(|e| format!("执行 evolution run 失败: runtime 初始化失败: {}", e))?
-        .block_on(skilllite_evolution::run_evolution(
-            &skilllite_core::paths::chat_root(),
-            skills_root.as_deref(),
-            &adapter,
-            &api_base,
-            &api_key,
-            &model,
-            true,
-        ));
-    match prev_force {
-        Some(v) => std::env::set_var(force_key, v),
-        None => std::env::remove_var(force_key),
-    }
-
-    let response = match run_result {
-        Ok(skilllite_evolution::EvolutionRunResult::Completed(Some(txn_id))) => {
-            let conn = skilllite_evolution::feedback::open_evolution_db(
-                &skilllite_core::paths::chat_root(),
-            )
-            .map_err(|e| format!("执行 evolution run 失败: 打开进化数据库失败: {}", e))?;
-            let changes = skilllite_evolution::query_changes_by_txn(&conn, &txn_id);
-            let summary: Vec<String> = skilllite_evolution::format_evolution_changes(&changes);
-            if summary.is_empty() {
-                format!("Evolution completed (txn={})", txn_id)
-            } else {
-                summary.join("\n")
-            }
-        }
-        Ok(skilllite_evolution::EvolutionRunResult::SkippedBusy) => {
-            "Evolution skipped: another run in progress".to_string()
-        }
-        Ok(skilllite_evolution::EvolutionRunResult::NoScope)
-        | Ok(skilllite_evolution::EvolutionRunResult::Completed(None)) => {
-            let mut hint = String::from("Evolution: nothing to evolve");
-            if let Ok(conn) = skilllite_evolution::feedback::open_evolution_db(
-                &skilllite_core::paths::chat_root(),
-            ) {
-                if let Ok((total, with_desc)) =
-                    skilllite_evolution::feedback::count_decisions_with_task_desc(&conn)
-                {
-                    if total > 0 && with_desc == 0 {
-                        hint.push_str("\n\n提示: 进化需要 task_description。当前未进化决策均无 task_description。");
-                    } else if total == 0 {
-                        let all_count: i64 = conn
-                            .query_row("SELECT COUNT(*) FROM decisions", [], |r| r.get(0))
-                            .unwrap_or(0);
-                        if all_count > 0 {
-                            hint.push_str(
-                                "\n\n提示: 未进化决策队列为空。已有决策均已标记为已进化。",
-                            );
-                            hint.push_str("\n请执行新任务积累新决策后再触发进化。");
-                        } else {
-                            hint.push_str("\n\n提示: 进化队列为空。请先运行 skilllite run 或 skilllite chat 积累决策。");
-                        }
-                    }
-                }
-            }
-            hint
-        }
-        Err(e) => return Err(format!("执行 evolution run 失败: {}", e)),
-    };
-
-    let mut clipped = response.clone();
-    if clipped.len() > 480 {
-        clipped.truncate(480);
-        clipped.push('…');
-    }
-    if let Ok(conn) =
-        skilllite_evolution::feedback::open_evolution_db(&skilllite_core::paths::chat_root())
-    {
-        let _ = skilllite_evolution::log_evolution_event(
-            &conn,
-            &skilllite_core::paths::chat_root(),
-            "manual_evolution_run_triggered",
-            proposal_id.unwrap_or("all"),
-            &clipped,
-            workspace,
-        );
-    }
-    Ok(clipped)
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let result: NodeResult = spawn_skilllite_json(skilllite_path, workspace, overrides.as_ref(), &arg_refs)?;
+    Ok(result.response)
 }

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/mod.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/mod.rs
@@ -6,6 +6,7 @@
 
 mod bundled_skills_sync;
 mod chat;
+mod evolution_cli;
 mod followup_suggestions;
 mod integrations;
 mod llm_routing_error;

--- a/crates/skilllite-assistant/src-tauri/tauri.conf.json
+++ b/crates/skilllite-assistant/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.1.29",
   "identifier": "com.skilllite.assistant",
   "build": {
-    "beforeDevCommand": "bash scripts/prebuild-skilllite.sh && npm run dev",
+    "beforeDevCommand": "bash scripts/dev-tauri.sh",
     "devUrl": "http://localhost:5173",
     "beforeBuildCommand": "bash scripts/prebuild-skilllite.sh && npm run build",
     "frontendDist": "../dist"

--- a/crates/skilllite-commands/src/evolution.rs
+++ b/crates/skilllite-commands/src/evolution.rs
@@ -3,6 +3,18 @@
 //! Provides `skilllite evolution {status,reset,disable,explain,run}` subcommands
 //! for inspecting, controlling, and debugging the self-evolution engine.
 
+pub use crate::evolution_desktop::{
+    confirm_pending_skill as desktop_confirm_pending_skill,
+    list_pending_skills as desktop_list_pending_skills, query_backlog_desktop,
+    query_proposal_status as desktop_query_proposal_status,
+    read_pending_skill_md as desktop_read_pending_skill_md,
+    reject_pending_skill as desktop_reject_pending_skill, EvolutionBacklogRowSnapshot,
+    EvolutionOpSnapshot, EvolutionProposalStatusSnapshot, PendingSkillSnapshot,
+};
+pub use crate::evolution_status::{
+    build_evolution_status_snapshot, cmd_status, EvolutionStatusParams, EvolutionStatusSnapshot,
+};
+
 use anyhow::Context;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -139,7 +151,19 @@ fn query_backlog_rows(
 }
 
 /// `skilllite evolution backlog` — query evolution backlog proposals.
-pub fn cmd_backlog(status: Option<&str>, risk: Option<&str>, limit: usize) -> Result<()> {
+pub fn cmd_backlog(
+    json: bool,
+    hide_closed: bool,
+    status: Option<&str>,
+    risk: Option<&str>,
+    limit: usize,
+) -> Result<()> {
+    if json && hide_closed {
+        let rows = query_backlog_desktop(limit)?;
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+
     let root = paths::chat_root();
     let status_filter = normalize_status_filter(status)?;
     let risk_filter = normalize_risk_filter(risk)?;
@@ -149,6 +173,24 @@ pub fn cmd_backlog(status: Option<&str>, risk: Option<&str>, limit: usize) -> Re
         risk_filter.as_deref(),
         limit,
     )?;
+
+    if json {
+        let out: Vec<EvolutionBacklogRowSnapshot> = rows
+            .into_iter()
+            .map(|r| EvolutionBacklogRowSnapshot {
+                proposal_id: r.proposal_id,
+                source: r.source,
+                risk_level: r.risk_level,
+                status: r.status,
+                acceptance_status: r.acceptance_status,
+                roi_score: r.roi_score,
+                updated_at: r.updated_at,
+                note: r.note,
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
 
     println!(
         "╭────────────────────────────────────────────────────────────────────────────────────╮"
@@ -199,140 +241,6 @@ pub fn cmd_backlog(status: Option<&str>, risk: Option<&str>, limit: usize) -> Re
             pid, source, risk, status, accept, row.roi_score, updated, note
         );
     }
-    Ok(())
-}
-
-/// `skilllite evolution status` — show evolution statistics, effectiveness, trends.
-pub fn cmd_status() -> Result<()> {
-    let root = paths::chat_root();
-    let conn = skilllite_evolution::feedback::open_evolution_db(&root)?;
-    let mode = skilllite_evolution::EvolutionMode::from_env();
-
-    // Header
-    println!("╭─────────────────────────────────────────────╮");
-    println!("│       SkillLite 自进化引擎状态               │");
-    println!("╰─────────────────────────────────────────────╯");
-    println!();
-
-    // Mode
-    let mode_str = match &mode {
-        skilllite_evolution::EvolutionMode::All => "全部启用 ✅",
-        skilllite_evolution::EvolutionMode::PromptsOnly => "仅 Prompts",
-        skilllite_evolution::EvolutionMode::MemoryOnly => "仅 Memory",
-        skilllite_evolution::EvolutionMode::SkillsOnly => "仅 Skills",
-        skilllite_evolution::EvolutionMode::Disabled => "已禁用 ⏸️  (已有进化产物冻结生效中)",
-    };
-    println!("进化模式: {}", mode_str);
-    println!();
-
-    // Recent metrics trend
-    println!("📈 核心指标趋势 (最近 7 天)");
-    println!(
-        "  {:10} {:>8} {:>8} {:>8}",
-        "日期", "成功率", "Replan", "纠正率"
-    );
-    println!(
-        "  {:10} {:>8} {:>8} {:>8}",
-        "──────────", "────────", "────────", "────────"
-    );
-
-    let mut stmt = conn
-        .prepare(
-            "SELECT date, first_success_rate, avg_replans, user_correction_rate
-         FROM evolution_metrics
-         WHERE date > date('now', '-7 days') ORDER BY date DESC",
-        )
-        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
-    let metrics = stmt
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, f64>(1)?,
-                row.get::<_, f64>(2)?,
-                row.get::<_, f64>(3)?,
-            ))
-        })
-        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
-
-    let mut has_metrics = false;
-    for m in metrics {
-        let (date, fsr, avg_r, ucr) = m.map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
-        println!(
-            "  {:10} {:>7.0}% {:>8.1} {:>7.0}%",
-            date,
-            fsr * 100.0,
-            avg_r,
-            ucr * 100.0,
-        );
-        has_metrics = true;
-    }
-    if !has_metrics {
-        println!("  (暂无数据 — 需要更多使用后才会出现)");
-    }
-    if let Ok(Some(summary)) = skilllite_evolution::feedback::build_latest_judgement(&conn) {
-        println!(
-            "  — 当前简单判断: {} ({})",
-            summary.judgement.label_zh(),
-            summary.judgement.as_str()
-        );
-        println!("    原因: {}", summary.reason);
-    }
-    println!();
-
-    // Recent evolution events
-    println!("📜 最近进化事件");
-    let mut stmt = conn
-        .prepare(
-            "SELECT ts, type, target_id, reason FROM evolution_log
-         ORDER BY ts DESC LIMIT 10",
-        )
-        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
-    let events = stmt
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, Option<String>>(2)?,
-                row.get::<_, Option<String>>(3)?,
-            ))
-        })
-        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
-
-    let mut has_events = false;
-    for e in events {
-        let (ts, etype, target, reason) =
-            e.map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
-        let date = &ts[..std::cmp::min(16, ts.len())];
-        let target = target.unwrap_or_default();
-        let reason = reason.unwrap_or_default();
-        let icon = match etype.as_str() {
-            "rule_added" => "✅",
-            "example_added" => "📖",
-            "skill_generated" => "✨",
-            "skill_pending" => "🆕",
-            "skill_refined" => "🔧",
-            "evolution_judgement" => "🧭",
-            "auto_rollback" => "⚠️ ",
-            t if t.contains("retired") => "🗑️ ",
-            t if t.contains("rolled_back") => "🔙",
-            _ => "  ",
-        };
-        let reason_short = if reason.len() > 50 {
-            format!("{}...", &reason[..47])
-        } else {
-            reason
-        };
-        println!("  {} {} {} {}", icon, date, etype, reason_short);
-        if !target.is_empty() {
-            println!("     └─ target: {}", target);
-        }
-        has_events = true;
-    }
-    if !has_events {
-        println!("  (暂无进化事件)");
-    }
-    println!();
-
     Ok(())
 }
 
@@ -561,44 +469,96 @@ pub fn cmd_explain(rule_id: &str) -> Result<()> {
 }
 
 /// `skilllite evolution confirm <skill_name>` — move pending skill to confirmed (A10).
-/// Skills are project-level: moves from _pending to _evolved within workspace/.skills/.
-/// Logs skill_confirmed to evolution.log for EvoTown reward (human-approved = effective).
-pub fn cmd_confirm(skill_name: &str) -> Result<()> {
-    let skills_root = resolve_skills_root(None).ok_or_else(|| {
-        crate::Error::validation("无法解析工作区。请在项目目录运行或设置 SKILLLITE_WORKSPACE。")
-    })?;
-    skilllite_evolution::skill_synth::confirm_pending_skill(&skills_root, skill_name)?;
-    let root = paths::chat_root();
-    if let Ok(conn) = skilllite_evolution::feedback::open_evolution_db(&root) {
-        let _ = skilllite_evolution::log_evolution_event(
-            &conn,
-            &root,
-            "skill_confirmed",
-            skill_name,
-            "user confirmed",
-            "",
+pub fn cmd_confirm(json: bool, workspace: &str, skill_name: &str) -> Result<()> {
+    desktop_confirm_pending_skill(workspace, skill_name)?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&EvolutionOpSnapshot {
+                ok: true,
+                message: Some(format!("Skill '{}' confirmed", skill_name)),
+            })?
         );
+    } else {
+        println!("✅ Skill '{}' 已确认加入", skill_name);
     }
-    println!("✅ Skill '{}' 已确认加入", skill_name);
     Ok(())
 }
 
 /// `skilllite evolution reject <skill_name>` — remove pending skill without adding (A10).
-pub fn cmd_reject(skill_name: &str) -> Result<()> {
-    let skills_root = resolve_skills_root(None).ok_or_else(|| {
-        crate::Error::validation("无法解析工作区。请在项目目录运行或设置 SKILLLITE_WORKSPACE。")
-    })?;
-    skilllite_evolution::skill_synth::reject_pending_skill(&skills_root, skill_name)?;
-    println!("✅ Skill '{}' 已拒绝", skill_name);
+pub fn cmd_reject(json: bool, workspace: &str, skill_name: &str) -> Result<()> {
+    desktop_reject_pending_skill(workspace, skill_name)?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&EvolutionOpSnapshot {
+                ok: true,
+                message: Some(format!("Skill '{}' rejected", skill_name)),
+            })?
+        );
+    } else {
+        println!("✅ Skill '{}' 已拒绝", skill_name);
+    }
+    Ok(())
+}
+
+/// `skilllite evolution pending` — list pending evolved skills for desktop UI.
+pub fn cmd_pending(json: bool, workspace: &str) -> Result<()> {
+    let rows = desktop_list_pending_skills(workspace)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+    } else if rows.is_empty() {
+        println!("(no pending skills)");
+    } else {
+        for row in rows {
+            println!("- {} (needs_review={})", row.name, row.needs_review);
+        }
+    }
+    Ok(())
+}
+
+/// `skilllite evolution proposal-status <proposal_id>` — single backlog row for desktop.
+pub fn cmd_proposal_status(json: bool, proposal_id: &str) -> Result<()> {
+    let row = desktop_query_proposal_status(proposal_id)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&row)?);
+    } else {
+        println!(
+            "{} status={} accept={} updated={}",
+            row.proposal_id, row.status, row.acceptance_status, row.updated_at
+        );
+        if let Some(note) = row.note.filter(|n| !n.is_empty()) {
+            println!("  note: {}", note);
+        }
+    }
     Ok(())
 }
 
 /// `skilllite evolution run` — run evolution once synchronously, output NodeResult with new_skill.
-/// Skills are written to workspace/.skills/_evolved/ (project-level).
-pub fn cmd_run(json_output: bool) -> Result<()> {
+pub fn cmd_run(
+    json_output: bool,
+    workspace: &str,
+    proposal_id: Option<&str>,
+    log_manual_trigger: bool,
+) -> Result<()> {
+    let ws_root = crate::evolution_status::resolve_workspace_root(workspace);
+    skilllite_core::config::load_dotenv_from_dir(&ws_root);
+    std::env::set_var(
+        skilllite_core::config::env_keys::paths::SKILLLITE_WORKSPACE,
+        ws_root.to_string_lossy().as_ref(),
+    );
+
     let root = paths::chat_root();
-    let skills_root = resolve_skills_root(None);
+    let skills_root = resolve_skills_root(Some(workspace));
     skilllite_core::config::ensure_default_output_dir();
+
+    let force_key = skilllite_core::config::env_keys::evolution::SKILLLITE_EVO_FORCE_PROPOSAL_ID;
+    let prev_force = std::env::var(force_key).ok();
+    if let Some(pid) = proposal_id.filter(|s| !s.trim().is_empty()) {
+        std::env::set_var(force_key, pid);
+    } else {
+        std::env::remove_var(force_key);
+    }
 
     let config = AgentConfig::from_env();
     if config.api_key.is_empty() {
@@ -695,6 +655,19 @@ pub fn cmd_run(json_output: bool) -> Result<()> {
             }
         }
     };
+
+    match prev_force {
+        Some(v) => std::env::set_var(force_key, v),
+        None => std::env::remove_var(force_key),
+    }
+
+    if log_manual_trigger {
+        let _ = crate::evolution_desktop::log_manual_evolution_trigger(
+            workspace,
+            proposal_id,
+            &response.response,
+        );
+    }
 
     if json_output {
         println!("{}", serde_json::to_string_pretty(&response)?);

--- a/crates/skilllite-commands/src/evolution_desktop.rs
+++ b/crates/skilllite-commands/src/evolution_desktop.rs
@@ -1,0 +1,212 @@
+//! Desktop-shaped evolution JSON (L2 contract). See `docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md`.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use skilllite_core::skill::discovery::resolve_skills_dir_with_legacy_fallback;
+
+use crate::evolution_status::resolve_workspace_root;
+use crate::Result;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvolutionBacklogRowSnapshot {
+    pub proposal_id: String,
+    pub source: String,
+    pub risk_level: String,
+    pub status: String,
+    pub acceptance_status: String,
+    pub roi_score: f64,
+    pub updated_at: String,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvolutionProposalStatusSnapshot {
+    pub proposal_id: String,
+    pub status: String,
+    pub acceptance_status: String,
+    pub updated_at: String,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingSkillSnapshot {
+    pub name: String,
+    pub needs_review: bool,
+    pub preview: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvolutionOpSnapshot {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+pub fn resolve_skills_root(workspace: &str) -> Result<PathBuf> {
+    let root = resolve_workspace_root(workspace);
+    skilllite_core::config::load_dotenv_from_dir(&root);
+    let skills = resolve_skills_dir_with_legacy_fallback(&root, "skills").effective_path;
+    if skills.is_dir() {
+        Ok(skills)
+    } else {
+        Err(crate::Error::validation(format!(
+            "skills directory not found under workspace: {}",
+            root.display()
+        )))
+    }
+}
+
+fn truncate_utf8(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &s[..end])
+}
+
+pub fn query_backlog_desktop(limit: usize) -> Result<Vec<EvolutionBacklogRowSnapshot>> {
+    let chat_root = skilllite_core::paths::chat_root();
+    let conn = skilllite_evolution::feedback::open_evolution_db(&chat_root)?;
+    let limit = limit.clamp(1, 200);
+    let mut stmt = conn
+        .prepare(
+            "SELECT proposal_id, source, risk_level, status, acceptance_status, roi_score, updated_at, COALESCE(note, '')
+         FROM evolution_backlog
+         WHERE NOT (
+           status = 'executed'
+           AND COALESCE(acceptance_status, '') IN ('met', 'not_met')
+         )
+         ORDER BY updated_at DESC
+         LIMIT ?1",
+        )
+        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
+    let rows = stmt
+        .query_map([limit as i64], |row| {
+            Ok(EvolutionBacklogRowSnapshot {
+                proposal_id: row.get(0)?,
+                source: row.get(1)?,
+                risk_level: row.get(2)?,
+                status: row.get(3)?,
+                acceptance_status: row.get(4)?,
+                roi_score: row.get(5)?,
+                updated_at: row.get(6)?,
+                note: row.get(7)?,
+            })
+        })
+        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
+    Ok(rows
+        .map(|r| r.map_err(|e| crate::Error::from(anyhow::Error::from(e))))
+        .collect::<Result<Vec<_>>>()?)
+}
+
+pub fn query_proposal_status(proposal_id: &str) -> Result<EvolutionProposalStatusSnapshot> {
+    let chat_root = skilllite_core::paths::chat_root();
+    let conn = skilllite_evolution::feedback::open_evolution_db(&chat_root)?;
+    conn.query_row(
+        "SELECT proposal_id, status, acceptance_status, updated_at, note
+         FROM evolution_backlog
+         WHERE proposal_id = ?1
+         LIMIT 1",
+        [proposal_id],
+        |row| {
+            Ok(EvolutionProposalStatusSnapshot {
+                proposal_id: row.get(0)?,
+                status: row.get(1)?,
+                acceptance_status: row.get(2)?,
+                updated_at: row.get(3)?,
+                note: row.get(4)?,
+            })
+        },
+    )
+    .map_err(|e| crate::Error::from(anyhow::Error::from(e)))
+}
+
+pub fn list_pending_skills(workspace: &str) -> Result<Vec<PendingSkillSnapshot>> {
+    let skills_root = resolve_skills_root(workspace)?;
+    Ok(
+        skilllite_evolution::skill_synth::list_pending_skills_with_review(&skills_root)
+            .into_iter()
+            .map(|(name, needs_review)| {
+                let path = skills_root
+                    .join("_evolved")
+                    .join("_pending")
+                    .join(&name)
+                    .join("SKILL.md");
+                let preview = std::fs::read_to_string(&path)
+                    .map(|s| truncate_utf8(&s, 4000))
+                    .unwrap_or_default();
+                PendingSkillSnapshot {
+                    name,
+                    needs_review,
+                    preview,
+                }
+            })
+            .collect(),
+    )
+}
+
+pub fn read_pending_skill_md(workspace: &str, skill_name: &str) -> Result<String> {
+    let skills_root = resolve_skills_root(workspace)?;
+    let path = skills_root
+        .join("_evolved")
+        .join("_pending")
+        .join(skill_name)
+        .join("SKILL.md");
+    if !path.is_file() {
+        return Err(crate::Error::validation(format!(
+            "pending skill not found: {}",
+            skill_name
+        )));
+    }
+    std::fs::read_to_string(&path).map_err(Into::into)
+}
+
+pub fn confirm_pending_skill(workspace: &str, skill_name: &str) -> Result<()> {
+    let skills_root = resolve_skills_root(workspace)?;
+    skilllite_evolution::skill_synth::confirm_pending_skill(&skills_root, skill_name)?;
+    let chat_root = skilllite_core::paths::chat_root();
+    if let Ok(conn) = skilllite_evolution::feedback::open_evolution_db(&chat_root) {
+        let _ = skilllite_evolution::log_evolution_event(
+            &conn,
+            &chat_root,
+            "skill_confirmed",
+            skill_name,
+            "user confirmed (assistant)",
+            "",
+        );
+    }
+    Ok(())
+}
+
+pub fn reject_pending_skill(workspace: &str, skill_name: &str) -> Result<()> {
+    let skills_root = resolve_skills_root(workspace)?;
+    skilllite_evolution::skill_synth::reject_pending_skill(&skills_root, skill_name)?;
+    Ok(())
+}
+
+pub fn log_manual_evolution_trigger(
+    workspace: &str,
+    proposal_id: Option<&str>,
+    summary: &str,
+) -> Result<()> {
+    let chat_root = skilllite_core::paths::chat_root();
+    let conn = skilllite_evolution::feedback::open_evolution_db(&chat_root)?;
+    let mut clipped = summary.to_string();
+    if clipped.len() > 480 {
+        clipped.truncate(480);
+        clipped.push('…');
+    }
+    let _ = skilllite_evolution::log_evolution_event(
+        &conn,
+        &chat_root,
+        "manual_evolution_run_triggered",
+        proposal_id.unwrap_or("all"),
+        &clipped,
+        workspace,
+    );
+    Ok(())
+}

--- a/crates/skilllite-commands/src/evolution_desktop.rs
+++ b/crates/skilllite-commands/src/evolution_desktop.rs
@@ -98,9 +98,8 @@ pub fn query_backlog_desktop(limit: usize) -> Result<Vec<EvolutionBacklogRowSnap
             })
         })
         .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
-    Ok(rows
-        .map(|r| r.map_err(|e| crate::Error::from(anyhow::Error::from(e))))
-        .collect::<Result<Vec<_>>>()?)
+    rows.map(|r| r.map_err(|e| crate::Error::from(anyhow::Error::from(e))))
+        .collect::<Result<Vec<_>>>()
 }
 
 pub fn query_proposal_status(proposal_id: &str) -> Result<EvolutionProposalStatusSnapshot> {

--- a/crates/skilllite-commands/src/evolution_status.rs
+++ b/crates/skilllite-commands/src/evolution_status.rs
@@ -1,0 +1,457 @@
+//! Machine-readable evolution status for desktop / integrators (`skilllite evolution status --json`).
+//!
+//! JSON shape matches `skilllite-assistant` `EvolutionStatusPayload` (L2 contract).
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use skilllite_core::config::env_keys::evolution as evo_env;
+use skilllite_core::skill::discovery::resolve_skills_dir_with_legacy_fallback;
+use skilllite_evolution::growth_schedule::GrowthScheduleConfig;
+use skilllite_evolution::{GrowthDueDiagnostics, PassiveScheduleDiagnostics};
+
+use crate::Result;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EvolutionLogEntrySnapshot {
+    pub ts: String,
+    #[serde(rename = "event_type")]
+    pub event_type: String,
+    pub target_id: Option<String>,
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub txn_id: Option<String>,
+}
+
+/// Desktop-compatible evolution status payload (see `ASSISTANT-SPLIT-ARCHITECTURE.md` §5.2).
+#[derive(Debug, Clone, Serialize)]
+pub struct EvolutionStatusSnapshot {
+    pub mode_key: String,
+    pub mode_label: String,
+    pub interval_secs: u64,
+    pub decision_threshold: i64,
+    pub weighted_signal_sum: i64,
+    pub weighted_trigger_min: i64,
+    pub signal_window: i64,
+    pub evo_profile_key: String,
+    pub evo_cooldown_hours: f64,
+    pub unprocessed_decisions: i64,
+    pub last_run_ts: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_material_run_ts: Option<String>,
+    pub judgement_label: Option<String>,
+    pub judgement_reason: Option<String>,
+    pub recent_events: Vec<EvolutionLogEntrySnapshot>,
+    pub pending_skill_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub a9: Option<GrowthDueDiagnostics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub passive: Option<PassiveScheduleDiagnostics>,
+    pub would_have_evolution_proposals: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub empty_proposals_reason: Option<String>,
+    pub db_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvolutionStatusParams {
+    pub workspace: String,
+    pub periodic_anchor_unix: Option<i64>,
+}
+
+pub(crate) fn resolve_workspace_root(workspace: &str) -> PathBuf {
+    let raw = workspace.trim();
+    let p = if raw.is_empty() {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    } else {
+        PathBuf::from(raw)
+    };
+    if p.is_absolute() {
+        p
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(p)
+    }
+}
+
+fn workspace_env_lookup(workspace_root: &Path, key: &str) -> Option<String> {
+    skilllite_core::config::parse_dotenv_from_dir(workspace_root)
+        .into_iter()
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v)
+        .or_else(|| std::env::var(key).ok())
+}
+
+fn evolution_mode_from_workspace(workspace_root: &Path) -> skilllite_evolution::EvolutionMode {
+    match workspace_env_lookup(workspace_root, evo_env::SKILLLITE_EVOLUTION).as_deref() {
+        None | Some("1") | Some("true") | Some("") => skilllite_evolution::EvolutionMode::All,
+        Some("0") | Some("false") => skilllite_evolution::EvolutionMode::Disabled,
+        Some("prompts") => skilllite_evolution::EvolutionMode::PromptsOnly,
+        Some("memory") => skilllite_evolution::EvolutionMode::MemoryOnly,
+        Some("skills") => skilllite_evolution::EvolutionMode::SkillsOnly,
+        _ => skilllite_evolution::EvolutionMode::All,
+    }
+}
+
+fn evolution_mode_labels(
+    mode: &skilllite_evolution::EvolutionMode,
+) -> (&'static str, &'static str) {
+    match mode {
+        skilllite_evolution::EvolutionMode::All => ("all", "全部启用"),
+        skilllite_evolution::EvolutionMode::PromptsOnly => ("prompts", "仅 Prompts"),
+        skilllite_evolution::EvolutionMode::MemoryOnly => ("memory", "仅 Memory"),
+        skilllite_evolution::EvolutionMode::SkillsOnly => ("skills", "仅 Skills"),
+        skilllite_evolution::EvolutionMode::Disabled => ("disabled", "已禁用"),
+    }
+}
+
+fn growth_schedule_for_workspace(workspace_root: &Path) -> GrowthScheduleConfig {
+    let mut c = GrowthScheduleConfig::from_env();
+    c.interval_secs =
+        workspace_env_lookup(workspace_root, evo_env::SKILLLITE_EVOLUTION_INTERVAL_SECS)
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(c.interval_secs);
+    c.raw_unprocessed_threshold = workspace_env_lookup(
+        workspace_root,
+        evo_env::SKILLLITE_EVOLUTION_DECISION_THRESHOLD,
+    )
+    .and_then(|v| v.parse().ok())
+    .unwrap_or(c.raw_unprocessed_threshold);
+    c
+}
+
+fn effective_evo_profile_key(workspace_root: &Path) -> &'static str {
+    match workspace_env_lookup(workspace_root, evo_env::SKILLLITE_EVO_PROFILE).as_deref() {
+        Some("demo") => "demo",
+        Some("conservative") => "conservative",
+        _ => "default",
+    }
+}
+
+fn effective_evo_cooldown_hours(workspace_root: &Path) -> f64 {
+    workspace_env_lookup(workspace_root, evo_env::SKILLLITE_EVO_COOLDOWN_HOURS)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or_else(|| skilllite_evolution::EvolutionThresholds::default().cooldown_hours)
+}
+
+fn existing_workspace_skills_root(workspace_root: &Path) -> Option<PathBuf> {
+    let skills_root =
+        resolve_skills_dir_with_legacy_fallback(workspace_root, "skills").effective_path;
+    skills_root.is_dir().then_some(skills_root)
+}
+
+/// Build evolution status snapshot (workspace `.env` + process env; no desktop UI overrides).
+pub fn build_evolution_status_snapshot(params: &EvolutionStatusParams) -> EvolutionStatusSnapshot {
+    let workspace_root = resolve_workspace_root(&params.workspace);
+    skilllite_core::config::load_dotenv_from_dir(&workspace_root);
+
+    let mode = evolution_mode_from_workspace(&workspace_root);
+    let (mode_key, mode_label) = evolution_mode_labels(&mode);
+    let schedule_cfg = growth_schedule_for_workspace(&workspace_root);
+
+    let mut pending_skill_count = 0;
+    if let Some(skills_root) = existing_workspace_skills_root(&workspace_root) {
+        pending_skill_count =
+            skilllite_evolution::skill_synth::list_pending_skills_with_review(&skills_root).len();
+    }
+
+    let chat_root = skilllite_core::paths::chat_root();
+    let mut db_error = None;
+    let mut unprocessed_decisions = 0i64;
+    let mut weighted_signal_sum = 0i64;
+    let mut recent_events = Vec::new();
+    let mut last_run_ts = None;
+    let mut last_material_run_ts = None;
+    let mut judgement_label = None;
+    let mut judgement_reason = None;
+    let mut a9 = None;
+    let mut passive = None;
+    let mut would_have_evolution_proposals = false;
+    let mut empty_proposals_reason = None;
+
+    match skilllite_evolution::feedback::open_evolution_db(&chat_root) {
+        Ok(conn) => {
+            if let Ok(c) = skilllite_evolution::feedback::count_unprocessed_decisions(&conn) {
+                unprocessed_decisions = c;
+            }
+            if let Ok(w) = skilllite_evolution::growth_schedule::weighted_unprocessed_signal_sum(
+                &conn,
+                schedule_cfg.signal_window,
+            ) {
+                weighted_signal_sum = w;
+            }
+            if let Ok(Some(summary)) = skilllite_evolution::feedback::build_latest_judgement(&conn)
+            {
+                judgement_label = Some(summary.judgement.label_zh().to_string());
+                judgement_reason = Some(summary.reason);
+            }
+            let last_attempt_sql = format!(
+                "SELECT ts FROM evolution_log WHERE type IN ('{}', '{}') ORDER BY ts DESC LIMIT 1",
+                skilllite_evolution::feedback::EVOLUTION_LOG_TYPE_RUN_MATERIAL,
+                skilllite_evolution::feedback::EVOLUTION_LOG_TYPE_RUN_NOOP,
+            );
+            if let Ok(mut stmt) = conn.prepare(&last_attempt_sql) {
+                if let Ok(mut rows) = stmt.query([]) {
+                    if let Ok(Some(row)) = rows.next() {
+                        last_run_ts = row.get(0).ok();
+                    }
+                }
+            }
+            let last_mat_sql = format!(
+                "SELECT ts FROM evolution_log WHERE type = '{}' ORDER BY ts DESC LIMIT 1",
+                skilllite_evolution::feedback::EVOLUTION_LOG_TYPE_RUN_MATERIAL,
+            );
+            if let Ok(mut stmt) = conn.prepare(&last_mat_sql) {
+                if let Ok(mut rows) = stmt.query([]) {
+                    if let Ok(Some(row)) = rows.next() {
+                        last_material_run_ts = row.get(0).ok();
+                    }
+                }
+            }
+
+            let now_unix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64;
+            a9 = skilllite_evolution::inspect_growth_due(
+                &conn,
+                now_unix,
+                params.periodic_anchor_unix,
+                &schedule_cfg,
+            )
+            .ok();
+            passive = skilllite_evolution::passive_schedule_diagnostics(&conn, &mode).ok();
+            would_have_evolution_proposals =
+                skilllite_evolution::would_have_evolution_proposals(&conn, mode.clone(), false)
+                    .unwrap_or(false);
+            if !would_have_evolution_proposals {
+                empty_proposals_reason =
+                    skilllite_evolution::describe_empty_evolution_proposals(&conn, &mode, false)
+                        .ok()
+                        .map(str::to_string);
+            }
+
+            if let Ok(mut stmt) = conn.prepare(
+                "SELECT ts, type, target_id, reason, version FROM evolution_log ORDER BY ts DESC LIMIT 25",
+            ) {
+                if let Ok(rows) = stmt.query_map([], |row| {
+                    let version: Option<String> = row.get(4)?;
+                    let txn_id = version
+                        .filter(|s| !s.trim().is_empty())
+                        .map(|s| s.trim().to_string());
+                    Ok(EvolutionLogEntrySnapshot {
+                        ts: row.get(0)?,
+                        event_type: row.get(1)?,
+                        target_id: row.get::<_, Option<String>>(2)?,
+                        reason: row.get::<_, Option<String>>(3)?,
+                        txn_id,
+                    })
+                }) {
+                    recent_events.extend(rows.flatten());
+                }
+            }
+        }
+        Err(e) => {
+            db_error = Some(format!("cannot open evolution database: {}", e));
+        }
+    }
+
+    EvolutionStatusSnapshot {
+        mode_key: mode_key.to_string(),
+        mode_label: mode_label.to_string(),
+        interval_secs: schedule_cfg.interval_secs,
+        decision_threshold: schedule_cfg.raw_unprocessed_threshold,
+        weighted_signal_sum,
+        weighted_trigger_min: schedule_cfg.weighted_min,
+        signal_window: schedule_cfg.signal_window,
+        evo_profile_key: effective_evo_profile_key(&workspace_root).to_string(),
+        evo_cooldown_hours: effective_evo_cooldown_hours(&workspace_root),
+        unprocessed_decisions,
+        last_run_ts,
+        last_material_run_ts,
+        judgement_label,
+        judgement_reason,
+        recent_events,
+        pending_skill_count,
+        a9,
+        passive,
+        would_have_evolution_proposals,
+        empty_proposals_reason,
+        db_error,
+    }
+}
+
+/// `skilllite evolution status` — human table or JSON snapshot.
+pub fn cmd_status(json: bool, workspace: &str, periodic_anchor_unix: Option<i64>) -> Result<()> {
+    if json {
+        let snapshot = build_evolution_status_snapshot(&EvolutionStatusParams {
+            workspace: workspace.to_string(),
+            periodic_anchor_unix,
+        });
+        println!("{}", serde_json::to_string_pretty(&snapshot)?);
+        return Ok(());
+    }
+    cmd_status_human(workspace)
+}
+
+fn cmd_status_human(workspace: &str) -> Result<()> {
+    let workspace_root = resolve_workspace_root(workspace);
+    skilllite_core::config::load_dotenv_from_dir(&workspace_root);
+    let root = skilllite_core::paths::chat_root();
+    let conn = skilllite_evolution::feedback::open_evolution_db(&root)?;
+    let mode = evolution_mode_from_workspace(&workspace_root);
+
+    println!("╭─────────────────────────────────────────────╮");
+    println!("│       SkillLite 自进化引擎状态               │");
+    println!("╰─────────────────────────────────────────────╯");
+    println!();
+
+    let (_, mode_label) = evolution_mode_labels(&mode);
+    println!("进化模式: {}", mode_label);
+    println!();
+
+    println!("📈 核心指标趋势 (最近 7 天)");
+    println!(
+        "  {:10} {:>8} {:>8} {:>8}",
+        "日期", "成功率", "Replan", "纠正率"
+    );
+    println!(
+        "  {:10} {:>8} {:>8} {:>8}",
+        "──────────", "────────", "────────", "────────"
+    );
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT date, first_success_rate, avg_replans, user_correction_rate
+         FROM evolution_metrics
+         WHERE date > date('now', '-7 days') ORDER BY date DESC",
+        )
+        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
+    let metrics = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, f64>(1)?,
+                row.get::<_, f64>(2)?,
+                row.get::<_, f64>(3)?,
+            ))
+        })
+        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
+
+    let mut has_metrics = false;
+    for m in metrics {
+        let (date, fsr, avg_r, ucr) = m.map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
+        println!(
+            "  {:10} {:>7.0}% {:>8.1} {:>7.0}%",
+            date,
+            fsr * 100.0,
+            avg_r,
+            ucr * 100.0,
+        );
+        has_metrics = true;
+    }
+    if !has_metrics {
+        println!("  (暂无数据 — 需要更多使用后才会出现)");
+    }
+    if let Ok(Some(summary)) = skilllite_evolution::feedback::build_latest_judgement(&conn) {
+        println!(
+            "  — 当前简单判断: {} ({})",
+            summary.judgement.label_zh(),
+            summary.judgement.as_str()
+        );
+        println!("    原因: {}", summary.reason);
+    }
+    println!();
+
+    println!("📜 最近进化事件");
+    let mut stmt = conn
+        .prepare(
+            "SELECT ts, type, target_id, reason FROM evolution_log
+         ORDER BY ts DESC LIMIT 10",
+        )
+        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
+    let events = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })
+        .map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
+
+    let mut has_events = false;
+    for e in events {
+        let (ts, etype, target, reason) =
+            e.map_err(|e| crate::Error::from(anyhow::Error::from(e)))?;
+        let date = &ts[..std::cmp::min(16, ts.len())];
+        let target = target.unwrap_or_default();
+        let reason = reason.unwrap_or_default();
+        let icon = match etype.as_str() {
+            "rule_added" => "✅",
+            "example_added" => "📖",
+            "skill_generated" => "✨",
+            "skill_pending" => "🆕",
+            "skill_refined" => "🔧",
+            "evolution_judgement" => "🧭",
+            "auto_rollback" => "⚠️ ",
+            t if t.contains("retired") => "🗑️ ",
+            t if t.contains("rolled_back") => "🔙",
+            _ => "  ",
+        };
+        let reason_short = if reason.len() > 50 {
+            format!("{}...", &reason[..47])
+        } else {
+            reason
+        };
+        println!("  {} {} {} {}", icon, date, etype, reason_short);
+        if !target.is_empty() {
+            println!("     └─ target: {}", target);
+        }
+        has_events = true;
+    }
+    if !has_events {
+        println!("  (暂无进化事件)");
+    }
+    println!();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evolution_status_snapshot_serializes_required_fields() {
+        let snap = EvolutionStatusSnapshot {
+            mode_key: "all".into(),
+            mode_label: "全部启用".into(),
+            interval_secs: 600,
+            decision_threshold: 10,
+            weighted_signal_sum: 0,
+            weighted_trigger_min: 3,
+            signal_window: 20,
+            evo_profile_key: "default".into(),
+            evo_cooldown_hours: 24.0,
+            unprocessed_decisions: 0,
+            last_run_ts: None,
+            last_material_run_ts: None,
+            judgement_label: None,
+            judgement_reason: None,
+            recent_events: vec![],
+            pending_skill_count: 0,
+            a9: None,
+            passive: None,
+            would_have_evolution_proposals: false,
+            empty_proposals_reason: None,
+            db_error: None,
+        };
+        let v = serde_json::to_value(&snap).expect("serialize");
+        assert!(v.get("mode_key").is_some());
+        assert!(v.get("would_have_evolution_proposals").is_some());
+        assert!(v.get("recent_events").is_some());
+    }
+}

--- a/crates/skilllite-commands/src/lib.rs
+++ b/crates/skilllite-commands/src/lib.rs
@@ -29,6 +29,10 @@ pub mod channel_serve;
 pub mod env;
 #[cfg(feature = "agent")]
 pub mod evolution;
+#[cfg(feature = "agent")]
+mod evolution_desktop;
+#[cfg(feature = "agent")]
+mod evolution_status;
 pub mod ide;
 pub mod init;
 pub mod migrate;

--- a/crates/skilllite-evolution/src/growth_schedule.rs
+++ b/crates/skilllite-evolution/src/growth_schedule.rs
@@ -120,7 +120,7 @@ pub fn signal_burst_due(conn: &Connection, cfg: &GrowthScheduleConfig) -> Result
 }
 
 /// Read-only A9 breakdown for UI / ops (does **not** advance the periodic anchor).
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GrowthDueDiagnostics {
     pub min_run_gap_secs: u64,
     pub min_run_gap_blocked: bool,

--- a/crates/skilllite-evolution/src/scope.rs
+++ b/crates/skilllite-evolution/src/scope.rs
@@ -1189,7 +1189,7 @@ fn should_evolve_impl(
 }
 
 /// Passive-side gates + window stats for UI (read-only).
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PassiveScheduleDiagnostics {
     pub evolution_disabled: bool,
     pub daily_runs_today: i64,

--- a/deny.toml
+++ b/deny.toml
@@ -7,8 +7,8 @@
 # Layering rules track `spec/architecture-boundaries.md`:
 # entry (skilllite, skilllite-assistant) -> commands/agent -> executor -> sandbox -> core.
 #
-# Desktop note (Phase 0, D1 + D4, 2026-04-20; rollback 2026-04-20 TASK-2026-045):
-# `skilllite-assistant` (Tauri) is a first-class entry and consumes
+# Desktop note (D1, 2026-04-20; rollback TASK-2026-045 — no skilllite-services yet):
+# Today: `skilllite-assistant` is allow-listed and consumes
 # `skilllite-{agent,sandbox,evolution}` directly; it is listed as an allowed
 # wrapper for those denied crates. The earlier `skilllite-services` shared
 # layer was rolled back (TASK-2026-045) after the duplication it was meant to
@@ -16,6 +16,7 @@
 # `skilllite-services`. The Desktop manifest deny invocation
 # (`cargo deny --manifest-path crates/skilllite-assistant/src-tauri/Cargo.toml check bans`)
 # remains in CI to enforce the boundary.
+# Target (D1′): thin client over released `skilllite` only — docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md
 
 [graph]
 # Resolve the same feature set CI builds with (full agent / artifact / swarm graph).

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -236,16 +236,16 @@ skilllite (main binary)
   ├── skilllite-channel            # standalone (no `skilllite-*` path deps); outbound adapters; inbound webhook MVP via `skilllite channel serve`; unified host lives in main binary via `skilllite gateway serve`
   └── skilllite-core (root)
 
-skilllite-assistant (Tauri desktop, first-class entry — Phase 0 D1)
-  ├── skilllite-core
-  ├── skilllite-fs
-  ├── skilllite-sandbox          (allow-listed wrapper in deny.toml)
-  ├── skilllite-agent            (allow-listed wrapper in deny.toml)
-  └── skilllite-evolution        (allow-listed wrapper in deny.toml)
+skilllite-assistant (Tauri desktop — optional distribution; split target)
+  ├── Today: path deps → skilllite-core, fs, sandbox, agent, evolution (D1 allow-list)
+  └── Target: subprocess-only → released skilllite binary (agent-rpc + CLI --json)
 
 Execution chain (CLI):  CLI/MCP/stdio_rpc → skilllite-commands → skilllite-agent → skilllite-executor → skilllite-sandbox → skilllite-core
-Execution chain (Desktop, today): Tauri command → skilllite_bridge → {agent | sandbox | evolution | core | fs} directly.
-Future direction (Phase 1+): both entries route shared flows through a new `skilllite-services` crate before reaching domain crates.
+Execution chain (Desktop, today): Tauri → skilllite_bridge → {agent-rpc child | in-process agent/sandbox/evolution | CLI child}.
+Execution chain (Desktop, target): Tauri → bridge → {L1 agent-rpc | L2 skilllite --json | L3 workspace files} only.
+
+See [Assistant split architecture](./ASSISTANT-SPLIT-ARCHITECTURE.md) for L1/L2/L3, migration phases P0–P5, and repo extraction checklist.
+Optional accelerator: `skilllite-services` in the engine repo (CLI + daemon surfaces); Assistant must not path-dep it at split time.
 
 Core doesn't depend on upper layers; Agent is Core's customer.
 ```

--- a/docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md
+++ b/docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md
@@ -1,0 +1,242 @@
+# SkillLite Assistant — split-ready architecture
+
+> **Status:** Target architecture and migration plan (2026-05). Describes how `skilllite-assistant` can live in a **separate repository** while `skilllite` remains the **engine** (sandbox, MCP, CLI, evolution).
+>
+> **Related:** [Entry points — Desktop](./ENTRYPOINTS-AND-DOMAINS.md#4-desktop-skilllite-assistant) · [Architecture](./ARCHITECTURE.md) · [Pick your path — Desktop (optional)](./START_PATHS.md#path-1-desktop)
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+
+| Goal | Rationale |
+|------|-----------|
+| **Independent release cadence** | Desktop installers (dmg/msi/AppImage) vs `pip`/CLI on PyPI/GitHub Releases. |
+| **Clear product boundary** | Engine = sandbox + MCP + `skilllite` binary; Assistant = optional GUI distribution. |
+| **Single engine contract** | Assistant talks to a **released** `skilllite` binary, not path-deps on `skilllite-agent` / `skilllite-evolution`. |
+| **Preserve UX** | Streaming chat, execution confirmations, evolution panel, Life Pulse, IDE layout — no feature regression at split time. |
+
+### Non-goals
+
+- Replacing `agent-rpc` with a terminal parser of `skilllite chat` output.
+- Embedding the full agent loop inside Tauri (duplicates engine, blocks split).
+- Making Assistant a second “first-class engine entry” with its own sandbox/evolution code paths.
+
+---
+
+## 2. Current vs target (summary)
+
+```text
+TODAY (monorepo, hybrid)
+────────────────────────
+skilllite-assistant (Tauri)
+  ├─ agent-rpc subprocess     ← chat (good)
+  ├─ skilllite CLI subprocess ← gateway, some skills, Life Pulse evolution run
+  └─ in-process Rust crates   ← evolution UI, followup LLM, runtime provision,
+                                 skill discovery, prompts FS  (blocks clean split)
+
+TARGET (split-ready)
+────────────────────
+skilllite-assistant repo
+  ├─ UI: React + Tauri commands
+  └─ Bridge: subprocess-only → skilllite binary (semver-pinned)
+
+skilllite repo (engine)
+  ├─ skilllite / skilllite-sandbox / MCP
+  └─ Stable machine APIs: agent-rpc + CLI --json (+ optional desktop-api)
+```
+
+---
+
+## 3. Layered integration model
+
+Assistant should use **three integration layers** only. Higher layers are preferred when they exist.
+
+| Layer | Mechanism | Use for |
+|-------|-----------|---------|
+| **L1 — Streaming RPC** | `skilllite agent-rpc` (JSON-Lines) | `agent_chat`, confirm/clarify, streaming tool events, multimodal images |
+| **L2 — CLI JSON** | `skilllite <subcommand> --json` (stdout) | Evolution status/backlog/pending, runtime probe/provision, skill list, gateway-adjacent ops |
+| **L3 — Files & env** | Workspace `.env`, `chat/`, `skills/` on disk | Prompts diff UI, transcript paths; **read-only** in Assistant where possible |
+
+```mermaid
+flowchart TB
+  subgraph assistant ["skilllite-assistant (GUI repo)"]
+    UI[React UI]
+    Bridge[Tauri bridge]
+    UI --> Bridge
+  end
+
+  subgraph engine ["skilllite (engine repo)"]
+    RPC[agent-rpc]
+    CLI[CLI --json]
+    Core[(chat/ skills/ sqlite)]
+    RPC --> Core
+    CLI --> Core
+  end
+
+  Bridge -->|L1 stdin/stdout| RPC
+  Bridge -->|L2 spawn + JSON| CLI
+  Bridge -->|L3 read/write allowed paths| Core
+```
+
+**Rule:** No `path = "../../skilllite-*"` in Assistant’s `Cargo.toml` at target state.
+
+---
+
+## 4. Current in-process map (migration backlog)
+
+| Area | Location (today) | Target |
+|------|------------------|--------|
+| Main chat | `skilllite_bridge/chat.rs` → `agent-rpc` | **Keep L1** |
+| Stop chat / confirm | same + `protocol.rs` | **Keep L1** |
+| Evolution status panel | `integrations/evolution_ui/status.rs` | **L2** `skilllite evolution status --json` (**shipped**) |
+| Evolution backlog / pending | `backlog.rs`, `pending.rs` | **L2** `backlog --json --hide-closed`, `pending --json`, `proposal-status --json`, `confirm`/`reject --json` (**shipped**) |
+| Manual evolution trigger | `trigger.rs` | **L2** `skilllite evolution run --json --log-manual-trigger` (**shipped**) |
+| Life Pulse `growth_due` | `growth.rs` + `life_pulse.rs` | **L2** status JSON (cache 30s); keep subprocess for `evolution run` |
+| Follow-up chips | `followup_suggestions.rs` (`LlmClient`) | **L1** new `agent-rpc` method *or* **L2** `skilllite suggest-followup --json` |
+| Runtime install UI | `desktop_services.rs` (`skilllite_sandbox`) | **L2** `skilllite runtime probe/provision` + progress on stderr |
+| Skill list / add | `skill_rpc.rs` + partial `core` | **L2** `skilllite` skill subcommands `--json` |
+| Prompts diff / write | `prompt_artifact.rs` + `skilllite-fs` | **L3** read snapshots via CLI; writes via allowlisted paths + `skilllite` or narrow FS helper |
+| Bundled skills sync | `bundled_skills_sync.rs` | **L2** `skilllite skills sync-bundled` (or keep copy-only in Assistant resources) |
+| Gateway manager | `gateway_manager.rs` | **L2** spawn `skilllite gateway serve` (already subprocess) |
+
+---
+
+## 5. Engine contracts (define before extract)
+
+### 5.1 L1 — `agent-rpc` (frozen baseline)
+
+Already documented in `crates/skilllite-agent/src/rpc.rs`. Assistant depends on:
+
+- Methods: `agent_chat`, `confirm`, `clarify`, `ping`
+- Events: `text_chunk`, `tool_call`, `confirmation_request`, `done`, `error`, …
+
+**Versioning:** Treat breaking changes to line protocol as **engine major** bump; Assistant declares `min_skilllite_version`.
+
+### 5.2 L2 — CLI JSON surface (to add / extend)
+
+Priority commands for parity with today’s Desktop bridge:
+
+| Command | JSON output | Notes |
+|---------|-------------|-------|
+| `skilllite evolution status --json` | `EvolutionStatusSnapshot` | **Shipped**; `--workspace`, `--periodic-anchor-unix` |
+| `skilllite evolution backlog --json --hide-closed` | `EvolutionBacklogRowSnapshot[]` | **Shipped** (desktop filter) |
+| `skilllite evolution pending --json` | `PendingSkillSnapshot[]` | **Shipped** |
+| `skilllite evolution proposal-status --json <id>` | `EvolutionProposalStatusSnapshot` | **Shipped** |
+| `skilllite evolution confirm/reject --json` | `EvolutionOpSnapshot` | **Shipped** |
+| `skilllite evolution run --json` | `NodeResult` | **Shipped**; `--workspace`, `--proposal-id`, `--log-manual-trigger` |
+| `skilllite runtime probe` | `RuntimeUiSnapshot` | |
+| `skilllite runtime provision` | progress lines on stderr, result JSON on stdout | |
+| `skilllite skills list` (desktop) | `DesktopSkillInfo[]` | Or reuse `list` with `--json` |
+| `skilllite suggest-followup` | `{ "suggestions": string[] }` | Optional; avoids extra RPC surface |
+
+**Convention:** `--json` always prints a single JSON document on stdout; human text on stderr only.
+
+### 5.3 L3 — Optional thin shared crate
+
+If Assistant needs typed parsers without linking `skilllite-agent`:
+
+- Publish **`skilllite-client`** (engine repo): protocol types + JSON schemas only, **no** sandbox/agent code.
+- Assistant depends on `skilllite-client` from crates.io; still spawns `skilllite` binary at runtime.
+
+Avoid path-dep on `skilllite-core` long term (constants like `env_keys` can live in `skilllite-client` or duplicate minimally).
+
+---
+
+## 6. Repository layout after split
+
+```text
+github.com/EXboys/skilllite          github.com/EXboys/skilllite-assistant  (example)
+────────────────────────────          ─────────────────────────────────────
+crates/skilllite-*                    crates/ (optional skilllite-client dep)
+skilllite/ binary                     skilllite-assistant/
+python-sdk/                           src-tauri/   (bridge → subprocess only)
+docs/en|zh/                           src/         (React)
+tutorials/                            .github/workflows/release-desktop.yml
+```
+
+**Engine repo** drops `crates/skilllite-assistant/` after cutover (or keeps a stub README pointing to the new repo for one release cycle).
+
+**Assistant repo** pins engine version:
+
+```json
+// tauri.conf / build script / runtime check
+"min_skilllite_version": "0.1.30"
+```
+
+Prebuild script: download or require `skilllite` on PATH; **no** `cargo install --path skilllite` from monorepo root.
+
+---
+
+## 7. Phased migration (monorepo first)
+
+| Phase | Scope | Exit criterion |
+|-------|--------|----------------|
+| **P0 — Docs** | This doc + ENTRYPOINTS target state | Contributors agree on L1/L2/L3 |
+| **P1 — Engine JSON** | Implement `--json` for evolution status, runtime, skills list | Desktop can parse without `skilllite_evolution::` |
+| **P2 — Bridge thin** | Replace in-process calls in `evolution_ui/*`, `followup_*`, `desktop_services` | `src-tauri/Cargo.toml` drops `skilllite-agent`, `skilllite-evolution`, `skilllite-sandbox` |
+| **P3 — Optional `skilllite-client`** | Extract types + protocol tests | Assistant uses crate from git/crates.io |
+| **P4 — Extract repo** | Move tree, CI, releases; stub in engine repo | Two repos green CI |
+| **P5 — Policy** | Update `deny.toml` (remove assistant wrappers); revise D1 wording | Architecture docs = implemented state |
+
+**Do not start P4 until P2 is green** (otherwise two repos inherit the same coupling).
+
+### Interim: `skilllite-services` (optional accelerator)
+
+If CLI JSON proliferation is too slow, a shared **`skilllite-services`** crate in the **engine** repo can host “desktop-facing” orchestration used by both CLI and Assistant via **one** library API — but Assistant still **must not** path-dep it at split time; only call through subprocess unless services are exposed as `skilllite desktop-serve` daemon. Prefer **L2 CLI JSON** over in-process services for split cleanliness.
+
+---
+
+## 8. CI and release
+
+| Concern | Engine repo | Assistant repo |
+|---------|-------------|----------------|
+| **CI** | `cargo test`, sandbox, MCP smoke | `npm test`, Tauri build matrix, **contract tests** against pinned `skilllite` release artifact |
+| **Release** | PyPI + GitHub `skilllite` binaries | dmg/msi/AppImage; bundles or installs engine via installer script |
+| **Contract tests** | Golden JSON for `--json` subcommands | Snapshot tests parsing engine output |
+
+**Contract test idea:** Assistant CI downloads `skilllite` vX from Releases, runs golden `evolution status --json`, compares to fixture.
+
+---
+
+## 9. Performance notes (split does not fix chat spawn)
+
+| Path | Impact |
+|------|--------|
+| Chat | Already one `agent-rpc` child per turn — unchanged |
+| Evolution status refresh | Moving in-process → CLI adds ~50–500ms unless **cached** (5–10s TTL in bridge) |
+| Evolution run | Already subprocess in Life Pulse — neutral |
+| Installer size | Assistant binary smaller without linked `agent`/`evolution` |
+
+---
+
+## 10. Policy change (D1 → D1′)
+
+**Historical (2026-04-20):** Desktop is a first-class entry with direct path deps (`deny.toml` allow-list).
+
+**Target (D1′):** Desktop is an **optional distribution channel** of the engine. It **must not** appear as a wrapper for `skilllite-agent` / `skilllite-sandbox` / `skilllite-evolution` in `deny.toml` after P2.
+
+Engine contributors optimize for **MCP + CLI**; Assistant contributors optimize for **bridge + UX**, consuming engine releases.
+
+---
+
+## 11. Open decisions
+
+| Topic | Options |
+|-------|---------|
+| Follow-up chips | `agent-rpc` method vs CLI subcommand |
+| Life Pulse preflight | Cached `evolution status --json` vs lightweight in-process schedule read (acceptable as L3 file read of `schedule.json` only) |
+| Repo name | `skilllite-assistant` vs `skilllite-desktop` |
+| Engine bundling | Installer ships fixed `skilllite` vs user-managed `pip install` |
+
+---
+
+## 12. Checklist before extracting repo
+
+- [ ] `src-tauri/Cargo.toml` has zero `skilllite-{agent,sandbox,evolution}` path dependencies
+- [ ] All bridge features covered by L1/L2/L3 table (section 4)
+- [ ] `min_skilllite_version` enforced at Assistant startup
+- [ ] EN/ZH docs and START_PATHS still mark Desktop as optional
+- [ ] Engine contract tests for `--json` outputs
+- [ ] `deny.toml` updated; ARCHITECTURE.md execution chain for Desktop = subprocess only

--- a/docs/en/ENTRYPOINTS-AND-DOMAINS.md
+++ b/docs/en/ENTRYPOINTS-AND-DOMAINS.md
@@ -47,15 +47,18 @@
 
 ## 4. Desktop (skilllite-assistant)
 
-- **Entry status**: First-class entry (Phase 0 D1, 2026-04-20). Architectural rules, dependency policy (`deny.toml`), CI checks (`cargo deny check bans` runs against this manifest in addition to the root workspace), documentation, and testing strategy treat Desktop on equal footing with the CLI. Desktop is **not** a thin shell over the installed binary.
-- **Entry**: Tauri app `skilllite-assistant`. Built via a separate Cargo manifest (`crates/skilllite-assistant/src-tauri/Cargo.toml`) and excluded from the root workspace because Tauri requires platform GUI toolchains (e.g. glib/GTK on Linux). Build with `cargo build --manifest-path crates/skilllite-assistant/src-tauri/Cargo.toml` or `npm run tauri build` from `crates/skilllite-assistant/`.
-- **Dependencies**:
-  - **Build time (direct path deps)**: `skilllite-core`, `skilllite-fs`, `skilllite-sandbox`, `skilllite-agent`, `skilllite-evolution`.
-  - **Runtime fallback**: For a subset of commands the bridge still spawns the installed `skilllite` binary (e.g. `agent-rpc` subprocess); see `crates/skilllite-assistant/README.md`. This is a runtime convenience, not a build-time requirement.
-- **Capabilities**: GUI chat, session management, evolution review/triggering, runtime probing/provisioning, transcript/memory/output views, IDE three-pane layout, image attachments to multimodal `agent_chat`.
-- **Chat input**: `Enter` sends; `Shift+Enter` inserts a newline; during an active IME composition, `Enter` is left to the IME (confirm candidates) and does not send.
-- **Use case**: Desktop users who prefer not to use the CLI; tray and shortcut scenarios.
-- **Boundary policy**: Direct dependencies on `skilllite-{agent,sandbox,evolution}` are explicitly allow-listed in `deny.toml` for now. Phase 1+ progressively moves shared flows behind a `skilllite-services` crate; existing direct deps remain permissible during migration. Reverting Desktop to a "shell" status would require explicitly overturning D1.
+- **Product role**: **Optional** GUI distribution of the engine — not the default integrator path ([Path 2 — Sandbox & MCP](./START_PATHS.md#path-2-sandbox-mcp) is). Can move to a **separate repository** once the split-ready contract is implemented ([Assistant split architecture](./ASSISTANT-SPLIT-ARCHITECTURE.md)).
+- **Entry (today)**: Tauri app under `crates/skilllite-assistant/`. Separate Cargo manifest (excluded from root workspace for Tauri/GUI toolchains). Build: `npm run tauri build` in that crate directory.
+- **Integration model (target)** — three layers only:
+  - **L1** `skilllite agent-rpc` — streaming chat, confirm/clarify (already used).
+  - **L2** `skilllite … --json` — evolution panel, runtime install, skill list (to complete; see split doc §5.2).
+  - **L3** Workspace files — prompts/transcript paths where UI reads disk directly.
+- **Dependencies (today vs target)**:
+  - **Today**: Direct path deps on `skilllite-core`, `skilllite-fs`, `skilllite-sandbox`, `skilllite-agent`, `skilllite-evolution` (allow-listed in `deny.toml`; historical D1, 2026-04-20).
+  - **Target (D1′)**: **No** path deps on engine crates; semver-pinned **`skilllite` binary** only (+ optional `skilllite-client` types crate).
+- **Capabilities**: GUI chat, session management, evolution review/triggering, runtime probing/provisioning, IDE layout, multimodal `agent_chat`.
+- **Use case**: Users who want a local app without wiring MCP in an IDE.
+- **Migration**: P0 docs → P1 engine `--json` → P2 thin bridge in monorepo → P4 extract repo ([checklist](./ASSISTANT-SPLIT-ARCHITECTURE.md#12-checklist-before-extracting-repo)).
 
 ---
 

--- a/docs/zh/ARCHITECTURE.md
+++ b/docs/zh/ARCHITECTURE.md
@@ -234,16 +234,16 @@ skilllite (主二进制)
   ├── skilllite-channel            # 独立 crate（无 `skilllite-*` path 依赖）；出站适配；入站 webhook MVP 为 `skilllite channel serve`；统一宿主在主二进制中通过 `skilllite gateway serve` 提供
   └── skilllite-core (根)
 
-skilllite-assistant（Tauri 桌面端，一等入口 — Phase 0 D1）
-  ├── skilllite-core
-  ├── skilllite-fs
-  ├── skilllite-sandbox          （在 deny.toml 中显式 allow-list）
-  ├── skilllite-agent            （在 deny.toml 中显式 allow-list）
-  └── skilllite-evolution        （在 deny.toml 中显式 allow-list）
+skilllite-assistant（Tauri 桌面 — 可选分发；拆仓目标）
+  ├── 现状：path 依赖 core、fs、sandbox、agent、evolution（D1 白名单）
+  └── 目标：仅子进程 → 已发布 skilllite 二进制（agent-rpc + CLI --json）
 
 执行链（CLI）：CLI/MCP/stdio_rpc → skilllite-commands → skilllite-agent → skilllite-executor → skilllite-sandbox → skilllite-core
-执行链（Desktop，当前）：Tauri command → skilllite_bridge → {agent | sandbox | evolution | core | fs} 直接调用。
-未来方向（Phase 1+）：CLI 与 Desktop 共享流程统一通过新建的 `skilllite-services` crate 再抵达领域 crate。
+执行链（Desktop，现状）：Tauri → skilllite_bridge → {agent-rpc 子进程 | 进程内 agent/sandbox/evolution | CLI 子进程}。
+执行链（Desktop，目标）：Tauri → bridge → 仅 {L1 agent-rpc | L2 skilllite --json | L3 工作区文件}。
+
+详见 [Assistant 可拆仓架构](./ASSISTANT-SPLIT-ARCHITECTURE.md)（L1/L2/L3、阶段 P0–P5、拆仓检查清单）。
+可选加速：引擎仓 `skilllite-services`（供 CLI/守护进程）；拆仓时 Assistant 不得 path 依赖该 crate。
 
 Core 不依赖上层；Agent 是 Core 的客户。
 ```

--- a/docs/zh/ASSISTANT-SPLIT-ARCHITECTURE.md
+++ b/docs/zh/ASSISTANT-SPLIT-ARCHITECTURE.md
@@ -1,0 +1,235 @@
+# SkillLite Assistant — 可拆仓架构
+
+> **状态：** 目标架构与迁移计划（2026-05）。说明 `skilllite-assistant` 如何迁入**独立仓库**，而 `skilllite` 继续作为**引擎**（沙箱、MCP、CLI、进化）。
+>
+> **相关：** [入口 — 桌面](./ENTRYPOINTS-AND-DOMAINS.md#4-desktopskilllite-assistant) · [架构说明](./ARCHITECTURE.md) · [选择路径 — 桌面（可选）](./START_PATHS.md#path-1-desktop)
+
+[English](../en/ASSISTANT-SPLIT-ARCHITECTURE.md)
+
+---
+
+## 1. 目标与非目标
+
+### 目标
+
+| 目标 | 原因 |
+|------|------|
+| **独立发布节奏** | 桌面安装包（dmg/msi/AppImage）与 PyPI/GitHub 上的 `pip`/CLI 解耦。 |
+| **产品边界清晰** | 引擎 = 沙箱 + MCP + `skilllite` 二进制；Assistant = 可选 GUI 分发渠道。 |
+| **单一引擎契约** | Assistant 只依赖**已发布**的 `skilllite` 二进制，不再 path 依赖 `skilllite-agent` / `skilllite-evolution`。 |
+| **体验不降级** | 流式聊天、执行确认、进化面板、Life Pulse、IDE 三栏 —— 拆仓时功能对齐。 |
+
+### 非目标
+
+- 用解析 `skilllite chat` 终端输出替代 `agent-rpc`。
+- 在 Tauri 内再嵌一套完整 Agent 循环（与引擎重复，阻碍拆仓）。
+- 让 Assistant 成为第二个「一等引擎入口」，自带沙箱/进化实现。
+
+---
+
+## 2. 现状 vs 目标（摘要）
+
+```text
+现状（monorepo，混合）
+────────────────────
+skilllite-assistant (Tauri)
+  ├─ agent-rpc 子进程     ← 聊天（保留）
+  ├─ skilllite CLI 子进程 ← gateway、部分 skill、Life Pulse 的 evolution run
+  └─ 进程内 Rust crate    ← 进化 UI、followup LLM、运行时安装、
+                             技能发现、prompts 写盘（阻碍干净拆仓）
+
+目标（可拆仓）
+────────────
+skilllite-assistant 独立仓库
+  ├─ UI：React + Tauri 命令
+  └─ Bridge：仅子进程 → skilllite 二进制（semver 钉扎）
+
+skilllite 引擎仓库
+  ├─ skilllite / skilllite-sandbox / MCP
+  └─ 稳定机器接口：agent-rpc + CLI --json（+ 可选 desktop-api）
+```
+
+---
+
+## 3. 分层集成模型
+
+Assistant **只使用三层集成**；有上层能力时优先上层。
+
+| 层 | 机制 | 用途 |
+|----|------|------|
+| **L1 — 流式 RPC** | `skilllite agent-rpc`（JSON-Lines） | `agent_chat`、确认/澄清、流式工具事件、多模态附图 |
+| **L2 — CLI JSON** | `skilllite <子命令> --json`（stdout） | 进化状态/backlog/pending、运行时探测/安装、技能列表、gateway 相关 |
+| **L3 — 文件与环境** | 工作区 `.env`、`chat/`、`skills/` | Prompts 对比 UI、transcript 路径；Assistant 尽量**只读** |
+
+```mermaid
+flowchart TB
+  subgraph assistant ["skilllite-assistant（GUI 仓）"]
+    UI[React UI]
+    Bridge[Tauri bridge]
+    UI --> Bridge
+  end
+
+  subgraph engine ["skilllite（引擎仓）"]
+    RPC[agent-rpc]
+    CLI[CLI --json]
+    Core[(chat/ skills/ sqlite)]
+    RPC --> Core
+    CLI --> Core
+  end
+
+  Bridge -->|L1 stdin/stdout| RPC
+  Bridge -->|L2 spawn + JSON| CLI
+  Bridge -->|L3 允许路径读写| Core
+```
+
+**规则：** 目标态下 Assistant 的 `Cargo.toml` **不得**再出现 `path = "../../skilllite-*"`。
+
+---
+
+## 4. 当前进程内调用映射（迁移 backlog）
+
+| 领域 | 现状位置 | 目标 |
+|------|----------|------|
+| 主聊天 | `skilllite_bridge/chat.rs` → `agent-rpc` | **保持 L1** |
+| 停止聊天 / 确认 | 同上 + `protocol.rs` | **保持 L1** |
+| 进化状态面板 | `status.rs` | **L2** `evolution status --json`（**已落地**） |
+| 进化 backlog / pending | `backlog.rs`、`pending.rs` | **L2** backlog/pending/proposal-status/confirm/reject `--json`（**已落地**） |
+| 手动触发进化 | `trigger.rs` | **L2** `evolution run --json --log-manual-trigger`（**已落地**） |
+| Life Pulse `growth_due` | `growth.rs` + `life_pulse.rs` | **L2** status JSON（缓存 30s）；`evolution run` 仍子进程 |
+| 猜你想问 | `followup_suggestions.rs`（`LlmClient`） | **L1** 扩展 `agent-rpc` *或* **L2** `skilllite suggest-followup --json` |
+| 运行时安装 UI | `desktop_services.rs`（`skilllite_sandbox`） | **L2** `skilllite runtime probe/provision` + stderr 进度 |
+| 技能列表 / 添加 | `skill_rpc.rs` + 部分 `core` | **L2** skill 子命令 `--json` |
+| Prompts 对比 / 写入 | `prompt_artifact.rs` + `skilllite-fs` | **L3** CLI 读快照；写入走白名单路径 + `skilllite` |
+| 内置技能同步 | `bundled_skills_sync.rs` | **L2** `skilllite skills sync-bundled`（或仅保留 Assistant 资源拷贝） |
+| Gateway | `gateway_manager.rs` | **L2** .spawn `skilllite gateway serve`（已是子进程） |
+
+---
+
+## 5. 引擎契约（拆仓前先定）
+
+### 5.1 L1 — `agent-rpc`（基线冻结）
+
+见 `crates/skilllite-agent/src/rpc.rs`。Assistant 依赖：
+
+- 方法：`agent_chat`、`confirm`、`clarify`、`ping`
+- 事件：`text_chunk`、`tool_call`、`confirmation_request`、`done`、`error` 等
+
+**版本：** 行协议破坏性变更 → 引擎 **major**；Assistant 声明 `min_skilllite_version`。
+
+### 5.2 L2 — CLI JSON 面（待补/扩展）
+
+与当前 Desktop bridge 对齐的优先子命令：
+
+| 命令 | JSON 输出 | 说明 |
+|------|-----------|------|
+| `skilllite evolution status --json` | `EvolutionStatusSnapshot` | **已落地**；`--workspace`、`--periodic-anchor-unix` |
+| `skilllite evolution backlog --json --hide-closed` | `EvolutionBacklogRowSnapshot[]` | **已落地**（桌面默认过滤） |
+| `skilllite evolution pending --json` | 待审核技能列表 | **已落地** |
+| `skilllite evolution proposal-status --json` | 单条 backlog | **已落地** |
+| `skilllite evolution confirm/reject --json` | 操作结果 | **已落地** |
+| `skilllite evolution run --json` | `NodeResult` | **已落地**；`--proposal-id`、`--log-manual-trigger` |
+| `skilllite runtime probe` | `RuntimeUiSnapshot` | |
+| `skilllite runtime provision` | stderr 进度 + stdout 结果 JSON | |
+| `skilllite skills list` | `DesktopSkillInfo[]` | 或扩展现有 `list --json` |
+| `skilllite suggest-followup` | `{ "suggestions": [...] }` | 可选 |
+
+**约定：** `--json` 仅在 stdout 输出**一个** JSON 文档；人类可读信息走 stderr。
+
+### 5.3 L3 — 可选薄共享 crate
+
+若 Assistant 需要类型解析但不想链接 `skilllite-agent`：
+
+- 引擎仓发布 **`skilllite-client`**：仅协议类型 + JSON schema，**不含**沙箱/agent 实现。
+- Assistant 从 crates.io 依赖 `skilllite-client`；运行时仍 spawn `skilllite` 二进制。
+
+长期避免 path 依赖 `skilllite-core`（`env_keys` 等可迁入 `skilllite-client` 或最小重复）。
+
+---
+
+## 6. 拆仓后的仓库布局
+
+```text
+github.com/EXboys/skilllite          github.com/EXboys/skilllite-assistant（示例）
+────────────────────────────          ─────────────────────────────────────
+crates/skilllite-*                    可选依赖 skilllite-client
+skilllite/ 二进制                     skilllite-assistant/
+python-sdk/                           src-tauri/（bridge → 仅子进程）
+docs/en|zh/                           src/（React）
+tutorials/                            release-desktop CI
+```
+
+**引擎仓** 在切换后移除 `crates/skilllite-assistant/`（或保留一期 README 指向新仓）。
+
+**Assistant 仓** 钉扎引擎版本，prebuild **不再** `cargo install --path skilllite` 从 monorepo 根目录构建。
+
+---
+
+## 7. 分阶段迁移（先在 monorepo 内完成）
+
+| 阶段 | 范围 | 完成标准 |
+|------|------|----------|
+| **P0 — 文档** | 本文 + ENTRYPOINTS 目标态 | 团队认同 L1/L2/L3 |
+| **P1 — 引擎 JSON** | evolution status、runtime、skills list 等 `--json` | Desktop 可不调用 `skilllite_evolution::` |
+| **P2 — Bridge 变薄** | 替换 `evolution_ui/*`、`followup_*`、`desktop_services` 内进程调用 | `Cargo.toml` 去掉 agent/evolution/sandbox path 依赖 |
+| **P3 — skilllite-client** | 抽出类型与协议测试 | Assistant 用 crates.io/git 依赖 |
+| **P4 — 拆仓库** | 迁移目录、CI、发布；引擎仓留 stub | 两仓 CI 绿 |
+| **P5 — 策略** | 更新 `deny.toml`、D1 表述 | 文档与实现一致 |
+
+**P2 未绿之前不要 P4**，否则两个仓库会复制同一份耦合。
+
+### 过渡：`skilllite-services`（可选加速）
+
+若 CLI JSON 膨胀过快，可在**引擎仓**建 `skilllite-services` 供 CLI 与 Assistant 共用逻辑，但拆仓时 Assistant **仍应**通过子进程调用，除非以 `skilllite desktop-serve` 守护进程暴露。为拆仓干净，**优先 L2 CLI JSON**，而非进程内 services。
+
+---
+
+## 8. CI 与发布
+
+| 项 | 引擎仓 | Assistant 仓 |
+|----|--------|----------------|
+| CI | `cargo test`、沙箱、MCP 冒烟 | `npm test`、Tauri 矩阵、对**钉扎版本** `skilllite` 的契约测试 |
+| 发布 | PyPI + GitHub 二进制 | 安装包；脚本捆绑或引导安装引擎 |
+| 契约测试 | `--json` 黄金输出 | 解析 fixture 快照 |
+
+---
+
+## 9. 性能说明（拆仓不解决聊天子进程）
+
+| 路径 | 影响 |
+|------|------|
+| 聊天 | 每轮已起 `agent-rpc` 子进程 —— 不变 |
+| 进化状态刷新 | 进程内 → CLI 增加约 50～500ms，需 **5～10s 缓存** |
+| 进化 run | Life Pulse 已是子进程 —— 中性 |
+| 安装包体积 | 不再静态链接 agent/evolution 后变小 |
+
+---
+
+## 10. 策略变更（D1 → D1′）
+
+**历史（2026-04-20）：** Desktop 为一等入口，允许 `deny.toml` 直接 path 依赖。
+
+**目标（D1′）：** Desktop 为引擎的**可选分发渠道**；P2 完成后不得再作为 `skilllite-agent` / `skilllite-sandbox` / `skilllite-evolution` 的 wrapper。
+
+引擎贡献者优先 **MCP + CLI**；Assistant 贡献者优先 **bridge + UX**，消费引擎发布物。
+
+---
+
+## 11. 待决事项
+
+| 话题 | 选项 |
+|------|------|
+| 猜你想问 | 扩展 `agent-rpc` vs CLI 子命令 |
+| Life Pulse 预检 | 缓存 `evolution status --json` vs 仅 L3 读 `schedule.json` |
+| 仓库名 | `skilllite-assistant` vs `skilllite-desktop` |
+| 引擎捆绑 | 安装包内置固定 `skilllite` vs 用户自行 `pip install` |
+
+---
+
+## 12. 拆仓前检查清单
+
+- [ ] `src-tauri/Cargo.toml` 无 `skilllite-{agent,sandbox,evolution}` path 依赖
+- [ ] 第 4 节能力均由 L1/L2/L3 覆盖
+- [ ] Assistant 启动时校验 `min_skilllite_version`
+- [ ] 中英文文档仍标 Desktop 为可选
+- [ ] 引擎侧 `--json` 契约测试
+- [ ] `deny.toml` 与 ARCHITECTURE 中 Desktop 执行链 = 仅子进程

--- a/docs/zh/ENTRYPOINTS-AND-DOMAINS.md
+++ b/docs/zh/ENTRYPOINTS-AND-DOMAINS.md
@@ -47,15 +47,18 @@
 
 ## 4. Desktop（skilllite-assistant）
 
-- **入口定级**：**一等入口**（Phase 0 D1，2026-04-20 决议）。架构规则、依赖策略（`deny.toml`）、CI 检查（`cargo deny check bans` 除 root workspace 外，**也对该 manifest 单独执行一次**）、文档与测试策略均与 CLI 同级；Desktop **不再被视为「外部二进制的薄壳」**。
-- **入口**：Tauri 应用 `skilllite-assistant`。使用单独的 Cargo manifest（`crates/skilllite-assistant/src-tauri/Cargo.toml`），因 Tauri 在 Linux 上需要 glib/GTK 等平台 GUI 工具链，故被 root workspace 排除。构建命令：`cargo build --manifest-path crates/skilllite-assistant/src-tauri/Cargo.toml`，或在 `crates/skilllite-assistant/` 下 `npm run tauri build`。
-- **依赖**：
-  - **编译时（直接 path 依赖）**：`skilllite-core`、`skilllite-fs`、`skilllite-sandbox`、`skilllite-agent`、`skilllite-evolution`。
-  - **运行时回退**：部分命令（如 `agent-rpc` 子进程）仍由 bridge 启动已安装的 `skilllite` 二进制，参见 `crates/skilllite-assistant/README.md`。这是**运行时便利**，不是编译时硬依赖。
-- **能力**：图形化聊天、会话管理、自进化审核与触发、运行时探测/供给、transcript/memory/输出视图、IDE 三栏布局、附图发往多模态 `agent_chat`。
-- **聊天输入**：`Enter` 发送；`Shift+Enter` 换行；**输入法组合输入（未上屏）**时回车交给输入法确认选词，不会发送。
-- **适用**：不想写命令行的桌面用户、需要常驻托盘与快捷方式的场景。
-- **边界策略**：当前对 `skilllite-{agent,sandbox,evolution}` 的直接依赖在 `deny.toml` 中显式列入 wrapper 白名单。Phase 1+ 会逐步把共享流程迁到 `skilllite-services` crate；现有直接依赖在迁移期间继续允许。把 Desktop 退回「壳」定位需要显式推翻 D1 决议。
+- **产品角色**：引擎的**可选 GUI 分发**，不是默认对接路径（默认见 [路径 2 — 沙箱与 MCP](./START_PATHS.md#path-2-sandbox-mcp)）。契约就绪后可迁入**独立仓库**（[Assistant 可拆仓架构](./ASSISTANT-SPLIT-ARCHITECTURE.md)）。
+- **入口（现状）**：`crates/skilllite-assistant/` 下的 Tauri 应用；单独 Cargo manifest（因 GUI 工具链未纳入 root workspace）。在该目录执行 `npm run tauri build`。
+- **集成模型（目标）** — 仅三层：
+  - **L1** `skilllite agent-rpc` — 流式聊天、确认/澄清（已用）。
+  - **L2** `skilllite … --json` — 进化面板、运行时安装、技能列表（待补，见拆仓文档 §5.2）。
+  - **L3** 工作区文件 — prompts/transcript 等允许路径的读写。
+- **依赖（现状 vs 目标）**：
+  - **现状**：path 依赖 `skilllite-core`、`skilllite-fs`、`skilllite-sandbox`、`skilllite-agent`、`skilllite-evolution`（`deny.toml` 白名单；历史 D1，2026-04-20）。
+  - **目标（D1′）**：**不再** path 依赖引擎 crate；仅 semver 钉扎的 **`skilllite` 二进制**（+ 可选 `skilllite-client` 类型 crate）。
+- **能力**：图形聊天、会话、进化审核/触发、运行时安装、IDE 三栏、多模态 `agent_chat`。
+- **适用**：不想在 IDE 里配 MCP、需要本机 App/托盘的用户。
+- **迁移**：P0 文档 → P1 引擎 `--json` → P2 monorepo 内 bridge 变薄 → P4 拆仓（[检查清单](./ASSISTANT-SPLIT-ARCHITECTURE.md#12-拆仓前检查清单)）。
 
 ---
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -586,6 +586,7 @@ MIT — 第三方依赖详见 [THIRD_PARTY_LICENSES.md](../../THIRD_PARTY_LICENS
 ## 📚 文档
 
 - [选择你的路径](./START_PATHS.md) — 沙箱/MCP（推荐）/ 全栈 / 可选桌面
+- [Assistant 可拆仓架构](./ASSISTANT-SPLIT-ARCHITECTURE.md) — 桌面独立仓库、L1/L2/L3 集成与迁移阶段
 - [快速入门](./GETTING_STARTED.md) — 安装和快速入门指南
 - [Channel 与 Gateway 配置指南](./GUIDE_CHANNEL_GATEWAY.md) — Webhook 入站、`SKILLLITE_CHANNEL_*` 摘要与桌面助手流程（含案例与流程图）
 - [更新日志](../../CHANGELOG.md) — 版本历史与升级说明

--- a/skilllite/src/cli.rs
+++ b/skilllite/src/cli.rs
@@ -753,6 +753,7 @@ pub enum Commands {
     ///
     /// Examples:
     ///   skilllite evolution status
+    ///   skilllite evolution status --json --workspace .
     ///   skilllite evolution reset
     ///   skilllite evolution confirm <name>
     #[cfg(feature = "agent")]
@@ -1026,10 +1027,29 @@ pub enum GatewayAction {
 #[derive(Subcommand, Debug)]
 pub enum EvolutionAction {
     /// Show evolution statistics, effectiveness scores, trends, and time profile
-    Status,
+    Status {
+        /// Emit desktop-compatible JSON on stdout (human metrics table when omitted)
+        #[arg(long)]
+        json: bool,
+        /// Project workspace root (loads `.env` from this directory)
+        #[arg(long, short = 'w', default_value = ".")]
+        workspace: String,
+        /// Life Pulse periodic arm anchor (unix seconds); omit for first-tick semantics
+        #[arg(long)]
+        periodic_anchor_unix: Option<i64>,
+    },
 
     /// Query evolution backlog proposals with optional filters
     Backlog {
+        /// Emit JSON array on stdout
+        #[arg(long)]
+        json: bool,
+        /// Hide executed rows with terminal acceptance (desktop default)
+        #[arg(long)]
+        hide_closed: bool,
+        /// Project workspace root
+        #[arg(long, short = 'w', default_value = ".")]
+        workspace: String,
         /// Filter by backlog status (e.g. queued/executing/executed/shadow_approved/policy_denied)
         #[arg(long)]
         status: Option<String>,
@@ -1039,6 +1059,22 @@ pub enum EvolutionAction {
         /// Max rows to display
         #[arg(long, default_value_t = 20)]
         limit: usize,
+    },
+
+    /// List pending evolved skills (desktop UI)
+    Pending {
+        #[arg(long)]
+        json: bool,
+        #[arg(long, short = 'w', default_value = ".")]
+        workspace: String,
+    },
+
+    /// Look up one backlog row by proposal_id
+    ProposalStatus {
+        #[arg(long)]
+        json: bool,
+        #[arg(value_name = "PROPOSAL_ID")]
+        proposal_id: String,
     },
 
     /// Reset to seed state — delete all evolved rules, examples, and skills
@@ -1064,23 +1100,36 @@ pub enum EvolutionAction {
 
     /// Confirm a pending evolved skill (A10) — move from _pending to _evolved (project-level)
     Confirm {
-        /// Skill name to confirm
+        #[arg(long)]
+        json: bool,
+        #[arg(long, short = 'w', default_value = ".")]
+        workspace: String,
         #[arg(value_name = "SKILL_NAME")]
         skill_name: String,
     },
 
     /// Reject a pending evolved skill (A10) — remove without adding
     Reject {
-        /// Skill name to reject
+        #[arg(long)]
+        json: bool,
+        #[arg(long, short = 'w', default_value = ".")]
+        workspace: String,
         #[arg(value_name = "SKILL_NAME")]
         skill_name: String,
     },
 
     /// Run evolution once synchronously — outputs NodeResult with new_skill when skill produced
     Run {
-        /// Output result as JSON (NodeResult format) for machine consumption
         #[arg(long)]
         json: bool,
+        #[arg(long, short = 'w', default_value = ".")]
+        workspace: String,
+        /// Force a specific backlog proposal_id for this run
+        #[arg(long)]
+        proposal_id: Option<String>,
+        /// Log `manual_evolution_run_triggered` after a successful run (desktop UI)
+        #[arg(long)]
+        log_manual_trigger: bool,
     },
 
     /// Repair skills: validate then LLM-fix failures. Without names, repair all failed; with names, only validate/repair those (faster when many skills).

--- a/skilllite/src/dispatch/mod.rs
+++ b/skilllite/src/dispatch/mod.rs
@@ -419,16 +419,35 @@ fn register_agent(reg: &mut CommandRegistry) {
         if let Commands::Evolution { action } = cmd {
             use crate::cli::EvolutionAction;
             let r = match action {
-                EvolutionAction::Status => skilllite_commands::evolution::cmd_status(),
+                EvolutionAction::Status {
+                    json,
+                    workspace,
+                    periodic_anchor_unix,
+                } => skilllite_commands::evolution::cmd_status(
+                    *json,
+                    workspace,
+                    *periodic_anchor_unix,
+                ),
                 EvolutionAction::Backlog {
+                    json,
+                    hide_closed,
+                    workspace: _,
                     status,
                     risk,
                     limit,
                 } => skilllite_commands::evolution::cmd_backlog(
+                    *json,
+                    *hide_closed,
                     status.as_deref(),
                     risk.as_deref(),
                     *limit,
                 ),
+                EvolutionAction::Pending { json, workspace } => {
+                    skilllite_commands::evolution::cmd_pending(*json, workspace)
+                }
+                EvolutionAction::ProposalStatus { json, proposal_id } => {
+                    skilllite_commands::evolution::cmd_proposal_status(*json, proposal_id)
+                }
                 EvolutionAction::Reset { force } => {
                     skilllite_commands::evolution::cmd_reset(*force)
                 }
@@ -438,13 +457,27 @@ fn register_agent(reg: &mut CommandRegistry) {
                 EvolutionAction::Explain { rule_id } => {
                     skilllite_commands::evolution::cmd_explain(rule_id)
                 }
-                EvolutionAction::Confirm { skill_name } => {
-                    skilllite_commands::evolution::cmd_confirm(skill_name)
-                }
-                EvolutionAction::Reject { skill_name } => {
-                    skilllite_commands::evolution::cmd_reject(skill_name)
-                }
-                EvolutionAction::Run { json } => skilllite_commands::evolution::cmd_run(*json),
+                EvolutionAction::Confirm {
+                    json,
+                    workspace,
+                    skill_name,
+                } => skilllite_commands::evolution::cmd_confirm(*json, workspace, skill_name),
+                EvolutionAction::Reject {
+                    json,
+                    workspace,
+                    skill_name,
+                } => skilllite_commands::evolution::cmd_reject(*json, workspace, skill_name),
+                EvolutionAction::Run {
+                    json,
+                    workspace,
+                    proposal_id,
+                    log_manual_trigger,
+                } => skilllite_commands::evolution::cmd_run(
+                    *json,
+                    workspace,
+                    proposal_id.as_deref(),
+                    *log_manual_trigger,
+                ),
                 EvolutionAction::RepairSkills {
                     skills,
                     from_source,


### PR DESCRIPTION
## Summary

- **Engine (L2):** Add `skilllite evolution` JSON subcommands for desktop UI — `status`, `backlog --hide-closed`, `pending`, `proposal-status`, `confirm`/`reject`, `run` (`--proposal-id`, `--log-manual-trigger`). New modules `evolution_status` and `evolution_desktop`.
- **Assistant bridge:** Prefer spawning `skilllite … --json` via `evolution_cli.rs`; keep in-process fallback for status/backlog/pending; manual evolution trigger is CLI-only.
- **Docs:** Add EN/ZH [Assistant split architecture](docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md) and link from architecture/entrypoints READMEs.
- **Dev UX:** `tauri dev` no longer runs full `cargo install --release` before Vite (fixes ~180s `localhost:5173` timeout). `dev-tauri.sh` starts Vite immediately; reuses an existing dev server on 5173 when healthy.

## Not in this PR

- EvoTown engine ingest spec (`docs/*/EVOTOWN-ENGINE-INGEST-V0.1.md`, OpenAPI) — left untracked for a separate PR.

## Test plan

- [x] `cargo test -p skilllite-commands --features agent evolution` (3 tests)
- [x] `cargo build -p skilllite`
- [x] `cargo check --manifest-path crates/skilllite-assistant/src-tauri/Cargo.toml`
- [x] Manual: `skilllite evolution backlog --json --hide-closed`, `pending --json`
- [ ] Manual: `npm run tauri dev` with/without existing Vite on :5173
- [ ] Manual: Desktop evolution panel (status, backlog, manual run)


Made with [Cursor](https://cursor.com)