### PR TITLE
feat(cli): runtime and skills list JSON for desktop L2

### DIFF
--- a/crates/skilllite-assistant/src-tauri/src/commands/desktop_health.rs
+++ b/crates/skilllite-assistant/src-tauri/src/commands/desktop_health.rs
@@ -24,8 +24,16 @@ pub async fn skilllite_git_status() -> crate::skilllite_bridge::GitUiStatus {
 }
 
 #[tauri::command]
-pub async fn skilllite_runtime_status() -> crate::skilllite_bridge::RuntimeUiSnapshot {
-    match tauri::async_runtime::spawn_blocking(crate::skilllite_bridge::probe_runtime_status).await
+pub async fn skilllite_runtime_status(
+    app: tauri::AppHandle,
+    workspace: Option<String>,
+) -> crate::skilllite_bridge::RuntimeUiSnapshot {
+    let ws = workspace.unwrap_or_else(|| ".".to_string());
+    let path = crate::skilllite_bridge::resolve_skilllite_path_app(&app);
+    match tauri::async_runtime::spawn_blocking(move || {
+        crate::skilllite_bridge::probe_runtime_status(&ws, Some(&path))
+    })
+    .await
     {
         Ok(s) => s,
         Err(_) => crate::skilllite_bridge::RuntimeUiSnapshot {
@@ -50,13 +58,16 @@ pub async fn skilllite_runtime_status() -> crate::skilllite_bridge::RuntimeUiSna
 #[tauri::command]
 pub async fn skilllite_provision_runtimes(
     app: tauri::AppHandle,
+    workspace: Option<String>,
     python: bool,
     node: bool,
     force: bool,
 ) -> Result<crate::skilllite_bridge::ProvisionRuntimesResult, String> {
+    let ws = workspace.unwrap_or_else(|| ".".to_string());
+    let path = crate::skilllite_bridge::resolve_skilllite_path_app(&app);
     let app = app.clone();
     tauri::async_runtime::spawn_blocking(move || {
-        crate::skilllite_bridge::provision_runtimes_with_emit(&app, python, node, force)
+        crate::skilllite_bridge::provision_runtimes_with_emit(&app, &ws, &path, python, node, force)
     })
     .await
     .map_err(|e| e.to_string())

--- a/crates/skilllite-assistant/src-tauri/src/commands/skills_workspace.rs
+++ b/crates/skilllite-assistant/src-tauri/src/commands/skills_workspace.rs
@@ -2,12 +2,16 @@
 
 #[tauri::command]
 pub async fn skilllite_list_skills(
+    app: tauri::AppHandle,
     workspace: Option<String>,
 ) -> Vec<crate::skilllite_bridge::DesktopSkillInfo> {
     let ws = workspace.unwrap_or_else(|| ".".to_string());
-    tauri::async_runtime::spawn_blocking(move || crate::skilllite_bridge::list_skills(&ws))
-        .await
-        .unwrap_or_default()
+    let path = crate::skilllite_bridge::resolve_skilllite_path_app(&app);
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::skilllite_bridge::list_skills(&ws, Some(&path))
+    })
+    .await
+    .unwrap_or_default()
 }
 
 #[tauri::command]

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/evolution_cli.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/evolution_cli.rs
@@ -1,12 +1,25 @@
-//! Spawn `skilllite` CLI with workspace env merge (L2 bridge for desktop evolution UI).
+//! Spawn `skilllite` CLI with workspace env merge (L2 bridge for desktop UI).
 
+use std::io::{BufRead, Read};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
 
 use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use skilllite_sandbox::{ProvisionRuntimesResult, RuntimeUiSnapshot};
 
 use super::chat::{merge_dotenv_with_chat_overrides, ChatConfigOverrides};
 use super::paths::{find_project_root, load_dotenv_for_child};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeProvisionProgressLine {
+    phase: String,
+    message: String,
+    percent: Option<u32>,
+}
 
 pub fn spawn_skilllite(
     skilllite_path: &Path,
@@ -51,6 +64,106 @@ pub fn spawn_skilllite_json<T: DeserializeOwned>(
             args.join(" "),
             e,
             output.stdout.len()
+        )
+    })
+}
+
+pub fn spawn_skilllite_runtime_probe(
+    skilllite_path: &Path,
+    workspace: &str,
+    cfg: Option<&ChatConfigOverrides>,
+) -> Result<RuntimeUiSnapshot, String> {
+    spawn_skilllite_json(skilllite_path, workspace, cfg, &["runtime", "probe", "--json"])
+}
+
+pub fn spawn_skilllite_runtime_provision<F>(
+    skilllite_path: &Path,
+    workspace: &str,
+    cfg: Option<&ChatConfigOverrides>,
+    python: bool,
+    node: bool,
+    force: bool,
+    mut on_progress: F,
+) -> Result<ProvisionRuntimesResult, String>
+where
+    F: FnMut(&str, &str, Option<u32>) + Send + 'static,
+{
+    let root = find_project_root(workspace);
+    let mut args: Vec<&str> = vec!["runtime", "provision", "--json"];
+    if python {
+        args.push("--python");
+    }
+    if node {
+        args.push("--node");
+    }
+    if force {
+        args.push("--force");
+    }
+
+    let mut cmd = Command::new(skilllite_path);
+    crate::windows_spawn::hide_child_console(&mut cmd);
+    cmd.args(&args);
+    let env_pairs = merge_dotenv_with_chat_overrides(load_dotenv_for_child(workspace), cfg);
+    for (k, v) in env_pairs {
+        cmd.env(k, v);
+    }
+    cmd.current_dir(&root)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("spawn skilllite {}: {}", args.join(" "), e))?;
+
+    let stderr = child.stderr.take();
+    let mut stdout = child.stdout.take();
+
+    let progress_rx = if let Some(stderr) = stderr {
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            let reader = std::io::BufReader::new(stderr);
+            for line in reader.lines() {
+                let Ok(line) = line else { continue };
+                if let Ok(p) = serde_json::from_str::<RuntimeProvisionProgressLine>(&line) {
+                    let _ = tx.send(p);
+                }
+            }
+        });
+        Some(rx)
+    } else {
+        None
+    };
+
+    let mut stdout_bytes = Vec::new();
+    if let Some(mut out) = stdout.take() {
+        out.read_to_end(&mut stdout_bytes)
+            .map_err(|e| format!("read skilllite stdout: {}", e))?;
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("wait skilllite {}: {}", args.join(" "), e))?;
+
+    if let Some(rx) = progress_rx {
+        while let Ok(p) = rx.try_recv() {
+            on_progress(&p.phase, &p.message, p.percent);
+        }
+    }
+
+    if !status.success() {
+        return Err(format!(
+            "skilllite {} failed (exit {:?})",
+            args.join(" "),
+            status.code()
+        ));
+    }
+
+    serde_json::from_slice(&stdout_bytes).map_err(|e| {
+        format!(
+            "parse skilllite {} JSON: {} (stdout len={})",
+            args.join(" "),
+            e,
+            stdout_bytes.len()
         )
     })
 }

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/desktop_services.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/desktop_services.rs
@@ -255,7 +255,17 @@ pub fn probe_git_status() -> GitUiStatus {
 }
 
 /// Python/Node 来源探测（系统 PATH vs SkillLite 缓存下载），供左侧栏等 UI 展示。
-pub fn probe_runtime_status() -> RuntimeUiSnapshot {
+pub fn probe_runtime_status(
+    workspace: &str,
+    skilllite_path: Option<&std::path::Path>,
+) -> RuntimeUiSnapshot {
+    if let Some(path) = skilllite_path {
+        if let Ok(snap) =
+            crate::skilllite_bridge::evolution_cli::spawn_skilllite_runtime_probe(path, workspace, None)
+        {
+            return snap;
+        }
+    }
     skilllite_sandbox::probe_runtime_for_ui(None)
 }
 
@@ -302,10 +312,36 @@ pub fn provision_runtimes(python: bool, node: bool, force: bool) -> ProvisionRun
 /// 与 [`provision_runtimes`] 相同，但通过 `skilllite-runtime-provision-progress` 事件推送进度文案。
 pub fn provision_runtimes_with_emit(
     app: &tauri::AppHandle,
+    workspace: &str,
+    skilllite_path: &std::path::Path,
     python: bool,
     node: bool,
     force: bool,
 ) -> ProvisionRuntimesResult {
+    let app_emit = app.clone();
+    let ws = workspace.to_string();
+    let path = skilllite_path.to_path_buf();
+    if let Ok(result) = crate::skilllite_bridge::evolution_cli::spawn_skilllite_runtime_provision(
+        &path,
+        &ws,
+        None,
+        python,
+        node,
+        force,
+        move |phase, message, percent| {
+            let _ = app_emit.emit(
+                "skilllite-runtime-provision-progress",
+                RuntimeProvisionProgressPayload {
+                    phase: phase.to_string(),
+                    message: message.to_string(),
+                    percent,
+                },
+            );
+        },
+    ) {
+        return result;
+    }
+
     let py_progress = if python {
         let app = app.clone();
         Some(Box::new(move |m: &str| {

--- a/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/skill_rpc.rs
+++ b/crates/skilllite-assistant/src-tauri/src/skilllite_bridge/integrations/skill_rpc.rs
@@ -4,14 +4,16 @@
 //! 可执行 CLI 与工作区目录，不承担 stdout 行协议解析。契约测试见同目录各子模块 `#[cfg(test)]`。
 
 use crate::skilllite_bridge::paths::{find_project_root, load_dotenv_for_child};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use skilllite_core::skill::{deps, manifest, metadata, trust::TrustTier};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::skilllite_bridge::evolution_cli::spawn_skilllite_json;
+
 use super::shared::{discover_skill_instances, find_skill_dir, resolve_workspace_skills_root};
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DesktopSkillInfo {
     pub name: String,
@@ -32,8 +34,22 @@ pub struct DesktopSkillInfo {
     pub missing_env_vars: Vec<String>,
 }
 
-/// List desktop skill infos in workspace using core-owned discovery.
-pub fn list_skills(workspace: &str) -> Vec<DesktopSkillInfo> {
+/// List desktop skill infos in workspace (L2 CLI first, in-process fallback).
+pub fn list_skills(workspace: &str, skilllite_path: Option<&Path>) -> Vec<DesktopSkillInfo> {
+    if let Some(path) = skilllite_path {
+        if let Ok(rows) = spawn_skilllite_json::<Vec<DesktopSkillInfo>>(
+            path,
+            workspace,
+            None,
+            &["skills", "list", "--json", "--workspace", workspace],
+        ) {
+            return rows;
+        }
+    }
+    list_skills_inprocess(workspace)
+}
+
+fn list_skills_inprocess(workspace: &str) -> Vec<DesktopSkillInfo> {
     let root = find_project_root(workspace);
     let mut manifest_cache = std::collections::HashMap::new();
     let mut skills = Vec::new();
@@ -398,7 +414,7 @@ pub fn add_skill(
         return Err(combined);
     }
     let added_skill_names = extract_added_skill_names(&combined);
-    let all_skills = list_skills(workspace);
+    let all_skills = list_skills_inprocess(workspace);
     Ok(summarise_add_output(
         &combined,
         &all_skills,
@@ -548,7 +564,7 @@ mod skill_discovery_tests {
         )
         .expect("evolved script");
 
-        let skills = list_skills(nested_skill.to_string_lossy().as_ref());
+        let skills = list_skills_inprocess(nested_skill.to_string_lossy().as_ref());
         let names: Vec<String> = skills.into_iter().map(|skill| skill.name).collect();
         assert_eq!(names, vec!["evolved-skill", "nested-skill"]);
         let _ = std::fs::remove_dir_all(&tmp);
@@ -565,7 +581,7 @@ mod skill_discovery_tests {
         )
         .expect("bash tool skill md");
 
-        let skills = list_skills(tmp.to_string_lossy().as_ref());
+        let skills = list_skills_inprocess(tmp.to_string_lossy().as_ref());
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "web-search");
         assert_eq!(skills[0].skill_type, "bash_tool");

--- a/crates/skilllite-commands/src/lib.rs
+++ b/crates/skilllite-commands/src/lib.rs
@@ -27,7 +27,6 @@ pub mod security;
 #[cfg(feature = "channel_serve")]
 pub mod channel_serve;
 pub mod env;
-pub mod runtime;
 #[cfg(feature = "agent")]
 pub mod evolution;
 #[cfg(feature = "agent")]
@@ -46,6 +45,7 @@ pub mod reindex;
 pub mod replay;
 #[cfg(feature = "agent")]
 pub mod replay_quality;
+pub mod runtime;
 #[cfg(feature = "agent")]
 pub mod schedule;
 pub mod skill;

--- a/crates/skilllite-commands/src/lib.rs
+++ b/crates/skilllite-commands/src/lib.rs
@@ -27,6 +27,7 @@ pub mod security;
 #[cfg(feature = "channel_serve")]
 pub mod channel_serve;
 pub mod env;
+pub mod runtime;
 #[cfg(feature = "agent")]
 pub mod evolution;
 #[cfg(feature = "agent")]

--- a/crates/skilllite-commands/src/runtime.rs
+++ b/crates/skilllite-commands/src/runtime.rs
@@ -1,0 +1,138 @@
+//! `skilllite runtime` — probe / provision Python & Node for desktop UI (L2 JSON).
+
+use serde::Serialize;
+use skilllite_sandbox::{
+    probe_runtime_for_ui, provision_runtimes_to_cache, ProvisionRuntimesResult, RuntimeUiSnapshot,
+};
+
+use crate::Result;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeProvisionProgressLine {
+    pub phase: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub percent: Option<u32>,
+}
+
+fn parse_percent_from_progress_message(msg: &str) -> Option<u32> {
+    for part in msg.split_whitespace() {
+        if let Some(n) = part.strip_suffix('%') {
+            if let Ok(p) = n.parse::<u32>() {
+                return Some(p.min(100));
+            }
+        }
+    }
+    None
+}
+
+fn emit_progress_line(phase: &str, message: &str) {
+    let line = RuntimeProvisionProgressLine {
+        phase: phase.to_string(),
+        message: message.to_string(),
+        percent: parse_percent_from_progress_message(message),
+    };
+    if let Ok(json) = serde_json::to_string(&line) {
+        eprintln!("{json}");
+    }
+}
+
+/// `skilllite runtime probe`
+pub fn cmd_probe(json: bool, cache_dir: Option<&str>) -> Result<()> {
+    let snap = probe_runtime_for_ui(cache_dir);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&snap)?);
+    } else {
+        print_runtime_human(&snap);
+    }
+    Ok(())
+}
+
+/// `skilllite runtime provision` — progress JSON lines on stderr when `--json`.
+pub fn cmd_provision(
+    json: bool,
+    cache_dir: Option<&str>,
+    download_python: bool,
+    download_node: bool,
+    force: bool,
+) -> Result<()> {
+    let py_progress = if download_python && json {
+        Some(Box::new(|m: &str| emit_progress_line("python", m)) as Box<dyn Fn(&str) + Send>)
+    } else {
+        None
+    };
+    let node_progress = if download_node && json {
+        Some(Box::new(|m: &str| emit_progress_line("node", m)) as Box<dyn Fn(&str) + Send>)
+    } else {
+        None
+    };
+
+    let result = provision_runtimes_to_cache(
+        cache_dir,
+        download_python,
+        download_node,
+        force,
+        py_progress,
+        node_progress,
+    );
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        print_provision_human(&result);
+    }
+    Ok(())
+}
+
+fn print_runtime_human(snap: &RuntimeUiSnapshot) {
+    println!("Python: {} ({})", snap.python.label, snap.python.source);
+    if let Some(d) = &snap.python.detail {
+        println!("  {d}");
+    }
+    println!("Node: {} ({})", snap.node.label, snap.node.source);
+    if let Some(d) = &snap.node.detail {
+        println!("  {d}");
+    }
+    if let Some(root) = &snap.cache_root {
+        println!("Cache: {root}");
+    }
+}
+
+fn print_provision_human(result: &ProvisionRuntimesResult) {
+    if result.python.requested {
+        println!(
+            "Python: {} — {}",
+            if result.python.ok { "ok" } else { "failed" },
+            result.python.message
+        );
+    }
+    if result.node.requested {
+        println!(
+            "Node: {} — {}",
+            if result.node.ok { "ok" } else { "failed" },
+            result.node.message
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_probe_json_roundtrip() {
+        let snap = probe_runtime_for_ui(None);
+        let v = serde_json::to_value(&snap).expect("serialize");
+        assert!(v.get("python").is_some());
+        assert!(v.get("node").is_some());
+    }
+
+    #[test]
+    fn progress_line_parses_percent() {
+        assert_eq!(
+            parse_percent_from_progress_message("Downloading… 42%"),
+            Some(42)
+        );
+    }
+}

--- a/crates/skilllite-commands/src/skill/desktop_list.rs
+++ b/crates/skilllite-commands/src/skill/desktop_list.rs
@@ -1,0 +1,279 @@
+//! `skilllite skills list --json` — workspace skill discovery for desktop UI (L2).
+
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use skilllite_core::skill::deps;
+use skilllite_core::skill::discovery::discover_skill_instances_in_workspace;
+use skilllite_core::skill::{manifest, metadata};
+use skilllite_core::skill::trust::TrustTier;
+
+use crate::Result;
+
+fn resolve_workspace_root(workspace: &str) -> PathBuf {
+    let raw = workspace.trim();
+    let p = if raw.is_empty() {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    } else {
+        PathBuf::from(raw)
+    };
+    if p.is_absolute() {
+        p
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| PathBuf::from("."))
+            .join(p)
+    }
+}
+
+/// Matches `skilllite-assistant` `DesktopSkillInfo` (camelCase JSON).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DesktopSkillSnapshot {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub skill_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    pub trust_tier: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trust_score: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub admission_risk: Option<String>,
+    pub dependency_type: String,
+    pub dependency_packages: Vec<String>,
+    pub missing_commands: Vec<String>,
+    pub missing_any_command_groups: Vec<Vec<String>>,
+    pub missing_env_vars: Vec<String>,
+}
+
+pub fn list_desktop_skills(workspace: &str) -> Vec<DesktopSkillSnapshot> {
+    let root = resolve_workspace_root(workspace);
+    let mut manifest_cache = HashMap::new();
+    let mut skills = Vec::new();
+    for skill in discover_skill_instances_in_workspace(&root, None) {
+        skills.push(build_desktop_skill_snapshot(
+            &skill.path,
+            &skill.name,
+            &mut manifest_cache,
+        ));
+    }
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    skills
+}
+
+/// `skilllite skills list`
+pub fn cmd_list_desktop(workspace: &str, json_output: bool) -> Result<()> {
+    let rows = list_desktop_skills(workspace);
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+    } else if rows.is_empty() {
+        eprintln!("(no skills found in workspace {})", workspace);
+    } else {
+        eprintln!("Skills in workspace {} ({}):", workspace, rows.len());
+        for row in rows {
+            eprintln!(
+                "  • {} [{}] trust={} deps={}",
+                row.name, row.skill_type, row.trust_tier, row.dependency_type
+            );
+        }
+    }
+    Ok(())
+}
+
+fn build_desktop_skill_snapshot(
+    skill_path: &Path,
+    fallback_name: &str,
+    manifest_cache: &mut HashMap<PathBuf, manifest::SkillManifest>,
+) -> DesktopSkillSnapshot {
+    let manifest_entry = manifest_entry_for_skill(skill_path, manifest_cache);
+    let parsed = metadata::parse_skill_metadata(skill_path).ok();
+    let name = parsed
+        .as_ref()
+        .map(|meta| meta.name.clone())
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| fallback_name.to_string());
+    let description = parsed.as_ref().and_then(|meta| meta.description.clone());
+    let skill_type = parsed
+        .as_ref()
+        .map(|meta| desktop_skill_type(skill_path, meta))
+        .unwrap_or_else(|| {
+            if metadata::has_executable_scripts(skill_path) {
+                "script".to_string()
+            } else {
+                "prompt_only".to_string()
+            }
+        });
+    let dependency = parsed
+        .as_ref()
+        .and_then(|meta| deps::detect_dependencies(skill_path, meta).ok());
+    let (missing_commands, missing_any_command_groups, missing_env_vars) = parsed
+        .as_ref()
+        .map(detect_missing_requirements)
+        .unwrap_or_default();
+
+    DesktopSkillSnapshot {
+        name,
+        description,
+        skill_type,
+        source: manifest_entry.as_ref().map(|entry| entry.source.clone()),
+        trust_tier: manifest_entry
+            .as_ref()
+            .map(|entry| trust_tier_label(entry.trust_tier.clone()))
+            .unwrap_or_else(|| "unknown".to_string()),
+        trust_score: manifest_entry.as_ref().map(|entry| entry.trust_score),
+        admission_risk: manifest_entry
+            .as_ref()
+            .and_then(|entry| entry.admission_risk.clone()),
+        dependency_type: dependency_type_label(dependency.as_ref().map(|dep| &dep.dep_type)),
+        dependency_packages: dependency
+            .as_ref()
+            .map(|dep| dep.packages.clone())
+            .unwrap_or_default(),
+        missing_commands,
+        missing_any_command_groups,
+        missing_env_vars,
+    }
+}
+
+fn manifest_entry_for_skill(
+    skill_path: &Path,
+    manifest_cache: &mut HashMap<PathBuf, manifest::SkillManifest>,
+) -> Option<manifest::SkillManifestEntry> {
+    let parent = skill_path.parent()?.to_path_buf();
+    if !manifest_cache.contains_key(&parent) {
+        manifest_cache.insert(
+            parent.clone(),
+            manifest::load_manifest(&parent).unwrap_or_default(),
+        );
+    }
+    let skill_key = skill_path.file_name()?.to_str()?;
+    manifest_cache
+        .get(&parent)
+        .and_then(|loaded| loaded.skills.get(skill_key).cloned())
+}
+
+fn desktop_skill_type(skill_path: &Path, meta: &metadata::SkillMetadata) -> String {
+    if !meta.entry_point.is_empty() || metadata::has_executable_scripts(skill_path) {
+        "script".to_string()
+    } else if meta.is_bash_tool_skill() {
+        "bash_tool".to_string()
+    } else {
+        "prompt_only".to_string()
+    }
+}
+
+fn trust_tier_label(tier: TrustTier) -> String {
+    match tier {
+        TrustTier::Trusted => "trusted",
+        TrustTier::Reviewed => "reviewed",
+        TrustTier::Community => "community",
+        TrustTier::Unknown => "unknown",
+    }
+    .to_string()
+}
+
+fn dependency_type_label(dep_type: Option<&deps::DependencyType>) -> String {
+    match dep_type {
+        Some(deps::DependencyType::Python) => "python",
+        Some(deps::DependencyType::Node) => "node",
+        _ => "none",
+    }
+    .to_string()
+}
+
+fn detect_missing_requirements(
+    meta: &metadata::SkillMetadata,
+) -> (Vec<String>, Vec<Vec<String>>, Vec<String>) {
+    let mut missing_commands = BTreeSet::new();
+    let mut missing_env_vars = BTreeSet::new();
+    let mut missing_any_command_groups = Vec::new();
+
+    for pattern in meta.get_bash_patterns() {
+        if !command_exists(&pattern.command_prefix) {
+            missing_commands.insert(pattern.command_prefix.clone());
+        }
+    }
+
+    let compatibility = meta.compatibility.as_deref();
+    for command in extract_compat_values(compatibility, "Requires bins: ") {
+        if !command_exists(&command) {
+            missing_commands.insert(command);
+        }
+    }
+    let any_group = extract_compat_values(compatibility, "Requires at least one bin: ");
+    if !any_group.is_empty() && !any_group.iter().any(|command| command_exists(command)) {
+        missing_any_command_groups.push(any_group);
+    }
+    for env_key in extract_compat_values(compatibility, "Requires env: ") {
+        if std::env::var_os(&env_key).is_none() {
+            missing_env_vars.insert(env_key);
+        }
+    }
+    for env_key in extract_compat_values(compatibility, "Primary credential env: ") {
+        if std::env::var_os(&env_key).is_none() {
+            missing_env_vars.insert(env_key);
+        }
+    }
+
+    (
+        missing_commands.into_iter().collect(),
+        missing_any_command_groups,
+        missing_env_vars.into_iter().collect(),
+    )
+}
+
+fn extract_compat_values(compatibility: Option<&str>, prefix: &str) -> Vec<String> {
+    let Some(compatibility) = compatibility else {
+        return Vec::new();
+    };
+    compatibility
+        .split('.')
+        .map(str::trim)
+        .filter_map(|segment| segment.strip_prefix(prefix))
+        .flat_map(|rest| rest.split(','))
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .map(std::string::ToString::to_string)
+        .collect()
+}
+
+fn command_exists(command: &str) -> bool {
+    let candidate = Path::new(command);
+    if candidate.components().count() > 1 {
+        return candidate.is_file();
+    }
+
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+
+    #[cfg(windows)]
+    let path_exts: Vec<String> = std::env::var_os("PATHEXT")
+        .map(|raw| {
+            raw.to_string_lossy()
+                .split(';')
+                .filter(|item| !item.is_empty())
+                .map(|item| item.trim_matches('.').to_ascii_lowercase())
+                .collect()
+        })
+        .unwrap_or_else(|| vec!["exe".to_string(), "cmd".to_string(), "bat".to_string()]);
+
+    for dir in std::env::split_paths(&paths) {
+        let direct = dir.join(command);
+        if direct.is_file() {
+            return true;
+        }
+        #[cfg(windows)]
+        for ext in &path_exts {
+            let with_ext = dir.join(format!("{command}.{ext}"));
+            if with_ext.is_file() {
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/crates/skilllite-commands/src/skill/desktop_list.rs
+++ b/crates/skilllite-commands/src/skill/desktop_list.rs
@@ -7,8 +7,8 @@ use std::path::{Path, PathBuf};
 use serde::Serialize;
 use skilllite_core::skill::deps;
 use skilllite_core::skill::discovery::discover_skill_instances_in_workspace;
-use skilllite_core::skill::{manifest, metadata};
 use skilllite_core::skill::trust::TrustTier;
+use skilllite_core::skill::{manifest, metadata};
 
 use crate::Result;
 

--- a/crates/skilllite-commands/src/skill/mod.rs
+++ b/crates/skilllite-commands/src/skill/mod.rs
@@ -5,6 +5,7 @@
 
 mod add;
 mod common;
+mod desktop_list;
 mod import_openclaw;
 mod list;
 mod remove;
@@ -17,6 +18,7 @@ pub use import_openclaw::cmd_import_openclaw_skills;
 pub(crate) use import_openclaw::{
     collect_openclaw_import_candidates, openclaw_workspace_candidates, SkillConflictPolicy,
 };
+pub use desktop_list::{cmd_list_desktop, list_desktop_skills, DesktopSkillSnapshot};
 pub use list::cmd_list;
 pub use remove::cmd_remove;
 pub use show::cmd_show;

--- a/crates/skilllite-commands/src/skill/mod.rs
+++ b/crates/skilllite-commands/src/skill/mod.rs
@@ -14,11 +14,11 @@ mod verify;
 
 pub use add::{cmd_add, update_skill_from_source};
 pub(crate) use common::resolve_skills_dir;
+pub use desktop_list::{cmd_list_desktop, list_desktop_skills, DesktopSkillSnapshot};
 pub use import_openclaw::cmd_import_openclaw_skills;
 pub(crate) use import_openclaw::{
     collect_openclaw_import_candidates, openclaw_workspace_candidates, SkillConflictPolicy,
 };
-pub use desktop_list::{cmd_list_desktop, list_desktop_skills, DesktopSkillSnapshot};
 pub use list::cmd_list;
 pub use remove::cmd_remove;
 pub use show::cmd_show;

--- a/crates/skilllite-sandbox/src/env/runtime_deps.rs
+++ b/crates/skilllite-sandbox/src/env/runtime_deps.rs
@@ -163,7 +163,7 @@ const DEFAULT_NODE_BASE: &str = "https://nodejs.org/dist";
 const FALLBACK_NODE_BASE: &str = "https://npmmirror.com/mirrors/node";
 
 /// Single runtime line for desktop UI (Python / Node): system PATH vs downloaded cache vs not yet provisioned.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeUiLine {
     /// `"system"` | `"cache"` | `"none"`
@@ -176,7 +176,7 @@ pub struct RuntimeUiLine {
     pub detail: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeUiSnapshot {
     pub python: RuntimeUiLine,
@@ -188,7 +188,7 @@ pub struct RuntimeUiSnapshot {
 }
 
 /// 桌面端「预下载内置运行时」单条结果
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProvisionRuntimeItem {
     pub requested: bool,
@@ -197,7 +197,7 @@ pub struct ProvisionRuntimeItem {
 }
 
 /// 一次预下载 Python / Node 的汇总（可只选其一）
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProvisionRuntimesResult {
     pub python: ProvisionRuntimeItem,

--- a/docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md
+++ b/docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md
@@ -95,8 +95,8 @@ flowchart TB
 | Manual evolution trigger | `trigger.rs` | **L2** `skilllite evolution run --json --log-manual-trigger` (**shipped**) |
 | Life Pulse `growth_due` | `growth.rs` + `life_pulse.rs` | **L2** status JSON (cache 30s); keep subprocess for `evolution run` |
 | Follow-up chips | `followup_suggestions.rs` (`LlmClient`) | **L1** new `agent-rpc` method *or* **L2** `skilllite suggest-followup --json` |
-| Runtime install UI | `desktop_services.rs` (`skilllite_sandbox`) | **L2** `skilllite runtime probe/provision` + progress on stderr |
-| Skill list / add | `skill_rpc.rs` + partial `core` | **L2** `skilllite` skill subcommands `--json` |
+| Runtime install UI | `desktop_services.rs` | **L2** `runtime probe/provision --json` (**shipped**; CLI first + in-process fallback) |
+| Skill list / add | `skill_rpc.rs` + partial `core` | **L2** `skills list --json` (**shipped** for list); add/repair still CLI subprocess |
 | Prompts diff / write | `prompt_artifact.rs` + `skilllite-fs` | **L3** read snapshots via CLI; writes via allowlisted paths + `skilllite` or narrow FS helper |
 | Bundled skills sync | `bundled_skills_sync.rs` | **L2** `skilllite skills sync-bundled` (or keep copy-only in Assistant resources) |
 | Gateway manager | `gateway_manager.rs` | **L2** spawn `skilllite gateway serve` (already subprocess) |
@@ -126,9 +126,9 @@ Priority commands for parity with today’s Desktop bridge:
 | `skilllite evolution proposal-status --json <id>` | `EvolutionProposalStatusSnapshot` | **Shipped** |
 | `skilllite evolution confirm/reject --json` | `EvolutionOpSnapshot` | **Shipped** |
 | `skilllite evolution run --json` | `NodeResult` | **Shipped**; `--workspace`, `--proposal-id`, `--log-manual-trigger` |
-| `skilllite runtime probe` | `RuntimeUiSnapshot` | |
-| `skilllite runtime provision` | progress lines on stderr, result JSON on stdout | |
-| `skilllite skills list` (desktop) | `DesktopSkillInfo[]` | Or reuse `list` with `--json` |
+| `skilllite runtime probe --json` | `RuntimeUiSnapshot` | **Shipped** |
+| `skilllite runtime provision --json` | stderr progress JSON lines + `ProvisionRuntimesResult` on stdout | **Shipped**; `--python` / `--node` / `--force` |
+| `skilllite skills list --json --workspace` | `DesktopSkillSnapshot[]` (desktop `DesktopSkillInfo`) | **Shipped** |
 | `skilllite suggest-followup` | `{ "suggestions": string[] }` | Optional; avoids extra RPC surface |
 
 **Convention:** `--json` always prints a single JSON document on stdout; human text on stderr only.

--- a/docs/zh/ASSISTANT-SPLIT-ARCHITECTURE.md
+++ b/docs/zh/ASSISTANT-SPLIT-ARCHITECTURE.md
@@ -97,8 +97,8 @@ flowchart TB
 | 手动触发进化 | `trigger.rs` | **L2** `evolution run --json --log-manual-trigger`（**已落地**） |
 | Life Pulse `growth_due` | `growth.rs` + `life_pulse.rs` | **L2** status JSON（缓存 30s）；`evolution run` 仍子进程 |
 | 猜你想问 | `followup_suggestions.rs`（`LlmClient`） | **L1** 扩展 `agent-rpc` *或* **L2** `skilllite suggest-followup --json` |
-| 运行时安装 UI | `desktop_services.rs`（`skilllite_sandbox`） | **L2** `skilllite runtime probe/provision` + stderr 进度 |
-| 技能列表 / 添加 | `skill_rpc.rs` + 部分 `core` | **L2** skill 子命令 `--json` |
+| 运行时安装 UI | `desktop_services.rs` | **L2** `runtime probe/provision --json`（**已落地**；CLI 优先 + 回退） |
+| 技能列表 / 添加 | `skill_rpc.rs` + 部分 `core` | **L2** `skills list --json`（列表**已落地**）；add/repair 仍为 CLI 子进程 |
 | Prompts 对比 / 写入 | `prompt_artifact.rs` + `skilllite-fs` | **L3** CLI 读快照；写入走白名单路径 + `skilllite` |
 | 内置技能同步 | `bundled_skills_sync.rs` | **L2** `skilllite skills sync-bundled`（或仅保留 Assistant 资源拷贝） |
 | Gateway | `gateway_manager.rs` | **L2** .spawn `skilllite gateway serve`（已是子进程） |
@@ -128,9 +128,9 @@ flowchart TB
 | `skilllite evolution proposal-status --json` | 单条 backlog | **已落地** |
 | `skilllite evolution confirm/reject --json` | 操作结果 | **已落地** |
 | `skilllite evolution run --json` | `NodeResult` | **已落地**；`--proposal-id`、`--log-manual-trigger` |
-| `skilllite runtime probe` | `RuntimeUiSnapshot` | |
-| `skilllite runtime provision` | stderr 进度 + stdout 结果 JSON | |
-| `skilllite skills list` | `DesktopSkillInfo[]` | 或扩展现有 `list --json` |
+| `skilllite runtime probe --json` | `RuntimeUiSnapshot` | **已落地** |
+| `skilllite runtime provision --json` | stderr 进度 JSON 行 + stdout `ProvisionRuntimesResult` | **已落地**；`--python` / `--node` / `--force` |
+| `skilllite skills list --json --workspace` | `DesktopSkillSnapshot[]`（对齐 `DesktopSkillInfo`） | **已落地** |
 | `skilllite suggest-followup` | `{ "suggestions": [...] }` | 可选 |
 
 **约定：** `--json` 仅在 stdout 输出**一个** JSON 文档；人类可读信息走 stderr。

--- a/skilllite/src/cli.rs
+++ b/skilllite/src/cli.rs
@@ -744,6 +744,25 @@ pub enum Commands {
         skills_dir: String,
     },
 
+    /// Python/Node runtime probe and provision (desktop UI)
+    ///
+    /// Examples:
+    ///   skilllite runtime probe --json
+    ///   skilllite runtime provision --json --python --node
+    Runtime {
+        #[command(subcommand)]
+        action: RuntimeAction,
+    },
+
+    /// Workspace skill discovery for desktop UI
+    ///
+    /// Examples:
+    ///   skilllite skills list --json --workspace .
+    Skills {
+        #[command(subcommand)]
+        action: SkillsAction,
+    },
+
     /// Manage the self-evolution engine (EVO-5)
     ///
     /// Subcommands:
@@ -1019,6 +1038,46 @@ pub enum GatewayAction {
         /// Mount artifact HTTP routes backed by this local directory when set
         #[arg(long, value_name = "DIR")]
         artifact_dir: Option<std::path::PathBuf>,
+    },
+}
+
+/// `skilllite runtime` subcommands.
+#[derive(Subcommand, Debug)]
+pub enum RuntimeAction {
+    /// Probe system vs cached Python/Node runtimes
+    Probe {
+        /// Emit `RuntimeUiSnapshot` JSON on stdout
+        #[arg(long)]
+        json: bool,
+        /// Override runtime cache directory
+        #[arg(long, value_name = "DIR")]
+        cache_dir: Option<String>,
+    },
+    /// Download bundled Python/Node into the runtime cache
+    Provision {
+        /// Emit `ProvisionRuntimesResult` JSON on stdout; progress lines on stderr
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        python: bool,
+        #[arg(long)]
+        node: bool,
+        #[arg(long)]
+        force: bool,
+        #[arg(long, value_name = "DIR")]
+        cache_dir: Option<String>,
+    },
+}
+
+/// `skilllite skills` subcommands.
+#[derive(Subcommand, Debug)]
+pub enum SkillsAction {
+    /// List skills discovered in a workspace (desktop-shaped JSON)
+    List {
+        #[arg(long)]
+        json: bool,
+        #[arg(long, short = 'w', default_value = ".")]
+        workspace: String,
     },
 }
 

--- a/skilllite/src/dispatch/mod.rs
+++ b/skilllite/src/dispatch/mod.rs
@@ -28,6 +28,8 @@ pub fn register_all(reg: &mut CommandRegistry) {
     channel_serve::register(reg);
     register_ide(reg);
     register_env(reg);
+    register_runtime(reg);
+    register_skills(reg);
     register_reindex(reg);
     register_wiki(reg);
     register_security(reg);
@@ -156,6 +158,51 @@ fn register_env(reg: &mut CommandRegistry) {
     reg.register(|cmd| {
         if let Commands::CleanEnv { dry_run, force } = cmd {
             Some(skilllite_commands::env::cmd_clean(*dry_run, *force).map_err(Into::into))
+        } else {
+            None
+        }
+    });
+}
+
+fn register_runtime(reg: &mut CommandRegistry) {
+    reg.register(|cmd| {
+        if let Commands::Runtime { action } = cmd {
+            use crate::cli::RuntimeAction;
+            let r = match action {
+                RuntimeAction::Probe { json, cache_dir } => {
+                    skilllite_commands::runtime::cmd_probe(*json, cache_dir.as_deref())
+                }
+                RuntimeAction::Provision {
+                    json,
+                    python,
+                    node,
+                    force,
+                    cache_dir,
+                } => skilllite_commands::runtime::cmd_provision(
+                    *json,
+                    cache_dir.as_deref(),
+                    *python,
+                    *node,
+                    *force,
+                ),
+            };
+            Some(r.map_err(Into::into))
+        } else {
+            None
+        }
+    });
+}
+
+fn register_skills(reg: &mut CommandRegistry) {
+    reg.register(|cmd| {
+        if let Commands::Skills { action } = cmd {
+            use crate::cli::SkillsAction;
+            let r = match action {
+                SkillsAction::List { json, workspace } => {
+                    skilllite_commands::skill::cmd_list_desktop(workspace, *json)
+                }
+            };
+            Some(r.map_err(Into::into))
         } else {
             None
         }


### PR DESCRIPTION
## Summary

Completes **P1** L2 JSON surface for desktop split (follow-up to #79):

- **`skilllite runtime probe --json`** → `RuntimeUiSnapshot`
- **`skilllite runtime provision --json`** → progress JSON lines on stderr, `ProvisionRuntimesResult` on stdout (`--python` / `--node` / `--force`)
- **`skilllite skills list --json --workspace`** → desktop-shaped `DesktopSkillSnapshot[]`

Assistant bridge prefers CLI for runtime status, provision (with stderr progress), and skill listing; keeps in-process fallback.

## Related

- #79 (evolution L2 + `tauri dev` fix) — already merged
- [Assistant split architecture](docs/en/ASSISTANT-SPLIT-ARCHITECTURE.md) §5.2 updated

## Test plan

- [x] `cargo build -p skilllite`
- [x] `cargo test -p skilllite-commands runtime` (2 tests)
- [x] `cargo check --manifest-path crates/skilllite-assistant/src-tauri/Cargo.toml`
- [x] `skilllite runtime probe --json`, `skills list --json --workspace .`
- [ ] Manual: Desktop **环境与依赖** (probe + provision progress)
- [ ] Manual: Desktop **技能** 列表刷新


Made with [Cursor](https://cursor.com)