### PR TITLE
chore: tidy module order and rustfmt after P2 merge

### DIFF
--- a/crates/skilllite-commands/src/lib.rs
+++ b/crates/skilllite-commands/src/lib.rs
@@ -48,7 +48,7 @@ pub mod replay_quality;
 pub mod runtime;
 #[cfg(feature = "agent")]
 pub mod schedule;
+pub mod skill;
 #[cfg(feature = "agent")]
 pub mod suggest_followup;
-pub mod skill;
 pub mod wiki;

--- a/crates/skilllite-commands/src/suggest_followup.rs
+++ b/crates/skilllite-commands/src/suggest_followup.rs
@@ -30,9 +30,8 @@ fn env_lookup(map: &HashMap<String, String>, primary: &str, aliases: &[&str]) ->
 }
 
 fn llm_from_env(workspace_root: &std::path::Path) -> Result<(String, String, String)> {
-    let mut map: HashMap<String, String> = parse_dotenv_from_dir(workspace_root)
-        .into_iter()
-        .collect();
+    let mut map: HashMap<String, String> =
+        parse_dotenv_from_dir(workspace_root).into_iter().collect();
     for (k, v) in std::env::vars() {
         map.entry(k).or_insert(v);
     }

--- a/skilllite/src/dispatch/mod.rs
+++ b/skilllite/src/dispatch/mod.rs
@@ -535,11 +535,7 @@ fn register_agent(reg: &mut CommandRegistry) {
                     outcome,
                     summary,
                 } => skilllite_commands::evolution::cmd_authorize_capability(
-                    *json,
-                    workspace,
-                    tool_name,
-                    outcome,
-                    summary,
+                    *json, workspace, tool_name, outcome, summary,
                 ),
                 EvolutionAction::Confirm {
                     json,


### PR DESCRIPTION
## Summary

Follow-up cleanup after #81 (assistant P2 split-ready):

- Reorder `skilllite-commands` `lib.rs` so `pub mod skill` precedes `suggest_followup` (alphabetical / consistency).
- Minor rustfmt in `suggest_followup.rs` and `evolution authorize-capability` dispatch wiring.

No behavior change.

## Test plan

- [x] `cargo check -p skilllite --features agent` (or equivalent CI)


Made with [Cursor](https://cursor.com)