### PR TITLE
fix(skilllite): gate suggest-followup registration behind agent feature

### DIFF
--- a/skilllite/src/dispatch/mod.rs
+++ b/skilllite/src/dispatch/mod.rs
@@ -32,7 +32,6 @@ pub fn register_all(reg: &mut CommandRegistry) {
     register_skills(reg);
     register_reindex(reg);
     register_wiki(reg);
-    register_suggest_followup(reg);
     register_security(reg);
     register_audit_report(reg);
     register_init(reg);
@@ -41,6 +40,7 @@ pub fn register_all(reg: &mut CommandRegistry) {
         register_quickstart(reg);
         register_agent(reg);
         register_schedule(reg);
+        register_suggest_followup(reg);
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes CI `E0425`: `register_suggest_followup` is only defined under `#[cfg(feature = "agent")]`, but was called unconditionally in `register_all()`.
- Moves `register_suggest_followup(reg)` into the existing `agent` feature block alongside `register_agent` and `register_schedule`.

## Test plan

- [x] `cargo check -p skilllite` (default features)
- [x] `cargo check -p skilllite --features agent`

Made with [Cursor](https://cursor.com)