### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+SkillLite is a Rust workspace (`Cargo.toml` at repo root) with a Python SDK (`python-sdk/`). The main binary is `skilllite` built from `skilllite/` crate. The desktop app (`crates/skilllite-assistant/`) is excluded from the workspace and is optional.
+
+### Running checks (mirrors CI)
+
+Rust:
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+cargo deny check bans
+```
+
+Python SDK (from `python-sdk/`):
+```bash
+ruff check .
+ruff format --check .
+mypy skilllite
+pytest
+```
+
+### Building
+
+```bash
+cargo build -p skilllite          # full binary (debug)
+cargo build -p skilllite --release  # release binary
+```
+
+### Running skills
+
+```bash
+# Sandbox Level 3 (default) requires kernel namespace support (bwrap).
+# In Cloud Agent VMs (nested containers), bwrap namespace creation fails with
+# "Resource temporarily unavailable". Use Level 1 for testing:
+SKILLLITE_SANDBOX_LEVEL=1 ./target/debug/skilllite run .skills/calculator '{"operation":"add","a":1,"b":2}'
+
+# For skills that trigger security scan (non-TTY stdin blocks approval):
+SKILLLITE_SANDBOX_LEVEL=1 SKILLLITE_AUTO_APPROVE=1 ./target/debug/skilllite run .skills/text-processor '{"text":"test","operation":"uppercase"}'
+```
+
+### Key gotchas
+
+- **Sandbox level in Cloud VMs**: `bwrap` (bubblewrap) requires unprivileged user namespaces which are unavailable inside the Cloud Agent container. Set `SKILLLITE_SANDBOX_LEVEL=1` for functional testing of skill execution logic. Security sandbox integration tests should be validated in CI (ubuntu-latest has namespace support).
+- **python3-venv**: Required for skill execution (`ensure_environment` creates venvs). Install with `sudo apt-get install -y python3.12-venv`.
+- **PATH for Python dev tools**: `ruff`, `mypy`, `pytest` install to `/home/ubuntu/.local/bin` — ensure it's on PATH.
+- **Rust toolchain**: The project uses latest stable Rust. Run `rustup default stable` if needed.
+- **Desktop app (Tauri)**: Not part of the default workspace (`exclude = ["crates/skilllite-assistant"]`). Requires Node.js + GTK libs on Linux. Skip unless specifically needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents, covering:

- How to run lint/test/build (mirrors CI pipeline)
- Key gotchas for Cloud Agent VMs (sandbox namespace limitations, python3-venv requirement, PATH setup)
- Quick reference for running skills with appropriate env vars

## Validation

All CI-equivalent checks pass in the Cloud Agent environment:

- `cargo fmt --check` — pass
- `cargo clippy --all-targets -- -D warnings` — pass  
- `cargo test` — 567 tests pass
- `cargo deny check bans` — pass
- Python SDK: `ruff check`, `ruff format --check`, `mypy`, `pytest` (23 tests) — all pass
- Application runs: `skilllite --version` (0.1.29), `skilllite list` (14 skills), skill execution verified

[dev_env_verification.log](https://cursor.com/agents/bc-353d6b10-cb23-47d2-aeb7-1c450fb6ec14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_env_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-353d6b10-cb23-47d2-aeb7-1c450fb6ec14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-353d6b10-cb23-47d2-aeb7-1c450fb6ec14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

