### PR TITLE
ci: add macOS Seatbelt sandbox smoke job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,3 +124,30 @@ jobs:
 
       - name: Check skilllite-sandbox binary
         run: cargo check -p skilllite --bin skilllite-sandbox --no-default-features --features sandbox_binary
+
+  macos-sandbox-smoke:
+    name: macOS sandbox smoke (Seatbelt)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify sandbox-exec is available
+        run: command -v sandbox-exec
+
+      - name: Run skilllite-sandbox macOS integration test
+        env:
+          SKILLLITE_AUTO_APPROVE: "1"
+        run: cargo test -p skilllite-sandbox --test macos_sandbox_smoke -- --nocapture
+
+      - name: Build skilllite (sandbox-only, for CLI smoke)
+        run: cargo build -p skilllite --bin skilllite --no-default-features --features sandbox_binary
+
+      - name: Run skilllite CLI Level 2 sandbox smoke
+        env:
+          SKILLLITE_AUTO_APPROVE: "1"
+          SKILLLITE_AUDIT_DISABLED: "1"
+        run: cargo test -p skilllite --test e2e_macos_sandbox --no-default-features --features sandbox_binary -- --nocapture

--- a/crates/skilllite-sandbox/tests/macos_sandbox_smoke.rs
+++ b/crates/skilllite-sandbox/tests/macos_sandbox_smoke.rs
@@ -1,0 +1,88 @@
+//! macOS Seatbelt (`sandbox-exec`) smoke test — exercises real Level 2 isolation on CI runners.
+//!
+//! Ubuntu CI uses `SKILLLITE_NO_SANDBOX=1` in `skilllite/tests/e2e_minimal.rs` because bubblewrap
+//! may be absent. macOS runners always ship `sandbox-exec`, so this test validates the production
+//! isolation path.
+
+#![cfg(target_os = "macos")]
+
+use skilllite_sandbox::runner::{
+    run_in_sandbox_with_limits_and_level, ResourceLimits, RuntimePaths, SandboxConfig,
+    SandboxLevel,
+};
+use std::fs;
+use std::path::PathBuf;
+
+fn resolve_python3() -> PathBuf {
+    which::which("python3").expect("python3 required for macOS sandbox smoke")
+}
+
+fn write_minimal_echo_skill(dir: &std::path::Path) {
+    fs::create_dir_all(dir.join("scripts")).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        r#"---
+name: macos-sandbox-smoke
+description: CI smoke skill for macOS Seatbelt.
+license: MIT
+---
+
+# macOS sandbox smoke
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("scripts").join("main.py"),
+        r#"#!/usr/bin/env python3
+import json, sys
+data = json.loads(sys.stdin.read())
+print(json.dumps({"echo": data.get("message", ""), "ok": True}))
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn macos_seatbelt_level2_executes_minimal_python_skill() {
+    std::env::remove_var("SKILLLITE_NO_SANDBOX");
+    std::env::remove_var("SKILLBOX_NO_SANDBOX");
+    std::env::set_var("SKILLLITE_AUTO_APPROVE", "1");
+
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_dir = tmp.path().join("smoke-skill");
+    write_minimal_echo_skill(&skill_dir);
+
+    let runtime = RuntimePaths {
+        python: resolve_python3(),
+        node: PathBuf::from("/usr/bin/false"),
+        node_modules: None,
+        env_dir: PathBuf::new(),
+    };
+    let config = SandboxConfig {
+        name: "macos-sandbox-smoke".to_string(),
+        entry_point: "scripts/main.py".to_string(),
+        language: "python".to_string(),
+        network_enabled: false,
+        network_outbound: Vec::new(),
+        uses_playwright: false,
+    };
+    let limits = ResourceLimits {
+        max_memory_mb: 256,
+        timeout_secs: 30,
+    };
+
+    let output = run_in_sandbox_with_limits_and_level(
+        &skill_dir,
+        &runtime,
+        &config,
+        r#"{"message":"seatbelt-smoke"}"#,
+        limits,
+        SandboxLevel::Level2,
+    )
+    .expect("Level 2 sandbox-exec smoke should succeed");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&output).expect("skill output must be valid JSON");
+    assert_eq!(parsed["echo"], "seatbelt-smoke");
+    assert_eq!(parsed["ok"], true);
+}

--- a/docs/en/CONTRIBUTING.md
+++ b/docs/en/CONTRIBUTING.md
@@ -58,7 +58,7 @@ cp .env.example .env
 - Follow standard Rust conventions
 - Run `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`
 - Run `cargo deny check bans` from the repo root before submitting (install: `cargo install cargo-deny --locked --version 0.18.6`, or match `.github/workflows/ci.yml`). This enforces crate layering in `deny.toml`.
-- PR CI runs full Rust/Python checks on Ubuntu and lightweight `cargo check` smoke on macOS and Windows.
+- PR CI runs full Rust/Python checks on Ubuntu, lightweight `cargo check` smoke on macOS and Windows, and a dedicated macOS Seatbelt sandbox smoke job (`sandbox-exec` Level 2 execution).
 
 ### Python
 - Follow PEP 8

--- a/docs/zh/CONTRIBUTING.md
+++ b/docs/zh/CONTRIBUTING.md
@@ -58,7 +58,7 @@ cp .env.example .env
 - 遵循标准 Rust 规范
 - 运行 `cargo fmt --check` 和 `cargo clippy --all-targets -- -D warnings`
 - 提交前在仓库根运行 `cargo deny check bans`（安装：`cargo install cargo-deny --locked --version 0.18.6`，或与 `.github/workflows/ci.yml` 中版本一致），用于校验 `deny.toml` 中的 crate 分层策略
-- PR CI 会在 Ubuntu 运行完整 Rust/Python 检查，并在 macOS 和 Windows 运行轻量 `cargo check` smoke。
+- PR CI 会在 Ubuntu 运行完整 Rust/Python 检查，在 macOS 和 Windows 运行轻量 `cargo check` smoke，并在 macOS 单独跑 Seatbelt 沙箱 smoke（`sandbox-exec` Level 2 真实执行）。
 
 ### Python
 - 遵循 PEP 8

--- a/skilllite/tests/e2e_macos_sandbox.rs
+++ b/skilllite/tests/e2e_macos_sandbox.rs
@@ -1,0 +1,101 @@
+//! macOS CLI smoke: `skilllite run --sandbox-level 2` through real Seatbelt isolation.
+//!
+//! Complements `e2e_minimal.rs` (Ubuntu, no sandbox) and `macos_sandbox_smoke.rs` (crate-level).
+
+#![cfg(target_os = "macos")]
+
+mod common;
+
+use common::{skilllite_bin, stderr_str, stdout_str};
+use std::path::Path;
+use std::process::Command;
+
+fn write_echo_skill(staging: &Path) {
+    std::fs::create_dir_all(staging.join("scripts")).unwrap();
+    std::fs::write(
+        staging.join("SKILL.md"),
+        r#"---
+name: e2e-macos-seatbelt
+description: Minimal echo skill for macOS sandbox CI.
+license: MIT
+---
+
+# macOS Seatbelt E2E
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        staging.join("scripts").join("main.py"),
+        r#"#!/usr/bin/env python3
+import json, sys
+data = json.loads(sys.stdin.read())
+print(json.dumps({"echo": data.get("message", ""), "ok": True}))
+"#,
+    )
+    .unwrap();
+}
+
+fn run_skilllite_sandboxed(args: &[&str], dir: &Path) -> std::process::Output {
+    Command::new(skilllite_bin())
+        .args(args)
+        .current_dir(dir)
+        .env("NO_COLOR", "1")
+        .env("SKILLLITE_AUTO_APPROVE", "1")
+        .env("SKILLLITE_AUDIT_DISABLED", "1")
+        .output()
+        .expect("failed to spawn skilllite")
+}
+
+#[test]
+fn e2e_macos_run_skill_level2_seatbelt() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let staging = root.join("staging-macos-seatbelt");
+    write_echo_skill(&staging);
+
+    let out = run_skilllite_sandboxed(
+        &[
+            "add",
+            staging.to_str().unwrap(),
+            "--scan-offline",
+            "-s",
+            ".skills",
+            "--force",
+        ],
+        root,
+    );
+    assert!(
+        out.status.success(),
+        "add failed: stdout={}\nstderr={}",
+        stdout_str(&out),
+        stderr_str(&out)
+    );
+
+    let installed = root.join(".skills").join("e2e-macos-seatbelt");
+    assert!(installed.join("SKILL.md").is_file());
+
+    let sp = installed.to_str().unwrap();
+    let out = run_skilllite_sandboxed(
+        &[
+            "run",
+            sp,
+            r#"{"message":"cli-seatbelt-smoke"}"#,
+            "--sandbox-level",
+            "2",
+        ],
+        root,
+    );
+    assert!(
+        out.status.success(),
+        "run failed: stdout={}\nstderr={}",
+        stdout_str(&out),
+        stderr_str(&out)
+    );
+
+    let combined = stdout_str(&out) + &stderr_str(&out);
+    assert!(
+        combined.contains("cli-seatbelt-smoke"),
+        "expected echoed payload in output: {}",
+        combined
+    );
+}


### PR DESCRIPTION
Run real Level 2 sandbox-exec tests on macOS CI to complement Ubuntu e2e which disables sandbox when bubblewrap is unavailable.

## Summary

- What problem does this PR solve?
- Why this approach?

## Task Linkage

- Task ID: `TASK-YYYY-NNN` (or `N/A` for lightweight external/community PRs)
- Task folder: `tasks/TASK-YYYY-NNN-.../` (optional in lightweight mode)

## Injected Specs

- [ ] `spec/architecture-boundaries.md` (if architecture/layering changed)
- [ ] `spec/security-nonnegotiables.md` (if sandbox/security changed)
- [ ] `spec/testing-policy.md` (required for any code change)
- [ ] `spec/docs-sync.md` (if behavior/docs/env/commands changed)

## Validation Evidence

- Commands executed:
  - `...`
- Key results:
  - `...`

## Regression Scope

- Areas likely affected:
  - `...`
- Explicit non-goals:
  - `...`

## Docs Sync (EN/ZH)

- [ ] Not needed
- [ ] Updated EN + ZH docs
- Files:
  - `...`

## Review Checklist

- [ ] Acceptance criteria in `tasks/.../TASK.md` satisfied (or explicitly deferred)
- [ ] `tasks/.../STATUS.md` updated with latest progress
- [ ] `tasks/.../REVIEW.md` includes merge readiness decision
- [ ] `tasks/board.md` status is up to date
