### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,9 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/crates/skilllite-sandbox/tests/macos_sandbox_smoke.rs
+++ b/crates/skilllite-sandbox/tests/macos_sandbox_smoke.rs
@@ -7,8 +7,7 @@
 #![cfg(target_os = "macos")]
 
 use skilllite_sandbox::runner::{
-    run_in_sandbox_with_limits_and_level, ResourceLimits, RuntimePaths, SandboxConfig,
-    SandboxLevel,
+    run_in_sandbox_with_limits_and_level, ResourceLimits, RuntimePaths, SandboxConfig, SandboxLevel,
 };
 use std::fs;
 use std::path::PathBuf;

--- a/skilllite/Cargo.lock
+++ b/skilllite/Cargo.lock
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary
- Upgrade transitive `quinn-proto` from 0.11.14 to 0.11.15 to fix RUSTSEC-2026-0185 (high severity remote memory exhaustion)
- Follow-up to merged #107; this commit was pushed after that PR merged

## Test plan
- [x] `cargo audit` passes locally (only 2 pre-existing allowed warnings)