### PR TITLE
fix(clippy): use Option::filter for sandbox level range check

### DIFF
--- a/crates/skilllite-core/src/config/schema.rs
+++ b/crates/skilllite-core/src/config/schema.rs
@@ -310,7 +310,7 @@ impl SandboxEnvConfig {
         )
         .parse::<u8>()
         .ok()
-        .and_then(|n| if (1..=3).contains(&n) { Some(n) } else { None })
+        .filter(|&n| (1..=3).contains(&n))
         .unwrap_or(3);
 
         let max_memory_mb = env_or(


### PR DESCRIPTION
## Summary
- Fix CI clippy failure (`clippy::manual_filter`) in `SandboxEnvConfig::from_env` by replacing `and_then` + `if` with `Option::filter`.

## Test plan
- [x] `cargo clippy -p skilllite-core --all-targets -- -D warnings`
- [ ] CI rust checks pass


Made with [Cursor](https://cursor.com)