### PR TITLE
fix(clippy): drop unneeded llm_usage wildcard in transcript match

### DIFF
--- a/crates/skilllite-agent/src/chat_session.rs
+++ b/crates/skilllite-agent/src/chat_session.rs
@@ -1335,7 +1335,6 @@ fn transcript_entry_to_message(entry: &transcript::TranscriptEntry) -> Option<Ch
             role,
             content,
             images,
-            llm_usage: _,
             ..
         } => {
             if role == "user" {


### PR DESCRIPTION
## Summary
- Fix CI clippy failure (`clippy::unneeded_wildcard_pattern`) in `transcript_entry_to_message` by removing redundant `llm_usage: _` covered by `..`.

## Test plan
- [x] `cargo clippy -p skilllite-agent --all-targets -- -D warnings`
- [ ] CI rust checks pass


Made with [Cursor](https://cursor.com)