### PR TITLE
fix(clippy): use ? in shebang scan and drop useless format borrow

### DIFF
--- a/crates/skilllite-commands/src/scan.rs
+++ b/crates/skilllite-commands/src/scan.rs
@@ -194,21 +194,15 @@ fn analyze_script_file(
         "ts" => ("typescript", true),
         "sh" | "bash" => ("shell", true),
         "" => {
-            if let Ok(content) = fs::read_to_string(file_path) {
-                if let Some(first_line) = content.lines().next() {
-                    if first_line.starts_with("#!") {
-                        if first_line.contains("python") {
-                            ("python", true)
-                        } else if first_line.contains("node") {
-                            ("node", true)
-                        } else if first_line.contains("bash") || first_line.contains("sh") {
-                            ("shell", true)
-                        } else {
-                            return None;
-                        }
-                    } else {
-                        return None;
-                    }
+            let content = fs::read_to_string(file_path).ok()?;
+            let first_line = content.lines().next()?;
+            if first_line.starts_with("#!") {
+                if first_line.contains("python") {
+                    ("python", true)
+                } else if first_line.contains("node") {
+                    ("node", true)
+                } else if first_line.contains("bash") || first_line.contains("sh") {
+                    ("shell", true)
                 } else {
                     return None;
                 }

--- a/crates/skilllite-commands/src/skill/add/admission.rs
+++ b/crates/skilllite-commands/src/skill/add/admission.rs
@@ -181,7 +181,7 @@ Rules:
     let v: serde_json::Value = serde_json::from_str(cleaned).with_context(|| {
         format!(
             "LLM risk JSON parse failed: {}",
-            &raw.chars().take(180).collect::<String>()
+            raw.chars().take(180).collect::<String>()
         )
     })?;
     let risk = match v


### PR DESCRIPTION
Unblocks CI -D warnings on skilllite-commands (question_mark, useless_borrows_in_formatting).

## Summary

- What problem does this PR solve?
- Why this approach?

## Task Linkage

- Task ID: `TASK-YYYY-NNN` (or `N/A` for lightweight external/community PRs)
- Task folder: `tasks/TASK-YYYY-NNN-.../` (optional in lightweight mode)

## Injected Specs

- [ ] `spec/architecture-boundaries.md` (if architecture/layering changed)
- [ ] `spec/security-nonnegotiables.md` (if sandbox/security changed)
- [ ] `spec/testing-policy.md` (required for any code change)
- [ ] `spec/docs-sync.md` (if behavior/docs/env/commands changed)

## Validation Evidence

- Commands executed:
  - `...`
- Key results:
  - `...`

## Regression Scope

- Areas likely affected:
  - `...`
- Explicit non-goals:
  - `...`

## Docs Sync (EN/ZH)

- [ ] Not needed
- [ ] Updated EN + ZH docs
- Files:
  - `...`

## Review Checklist

- [ ] Acceptance criteria in `tasks/.../TASK.md` satisfied (or explicitly deferred)
- [ ] `tasks/.../STATUS.md` updated with latest progress
- [ ] `tasks/.../REVIEW.md` includes merge readiness decision
- [ ] `tasks/board.md` status is up to date
