### PR TITLE
fix(clippy): question_mark and useless borrow in commands

### DIFF
--- a/crates/skilllite-commands/src/scan.rs
+++ b/crates/skilllite-commands/src/scan.rs
@@ -195,17 +195,14 @@ fn analyze_script_file(
         "sh" | "bash" => ("shell", true),
         "" => {
             if let Ok(content) = fs::read_to_string(file_path) {
-                if let Some(first_line) = content.lines().next() {
-                    if first_line.starts_with("#!") {
-                        if first_line.contains("python") {
-                            ("python", true)
-                        } else if first_line.contains("node") {
-                            ("node", true)
-                        } else if first_line.contains("bash") || first_line.contains("sh") {
-                            ("shell", true)
-                        } else {
-                            return None;
-                        }
+                let first_line = content.lines().next()?;
+                if first_line.starts_with("#!") {
+                    if first_line.contains("python") {
+                        ("python", true)
+                    } else if first_line.contains("node") {
+                        ("node", true)
+                    } else if first_line.contains("bash") || first_line.contains("sh") {
+                        ("shell", true)
                     } else {
                         return None;
                     }

--- a/crates/skilllite-commands/src/skill/add/admission.rs
+++ b/crates/skilllite-commands/src/skill/add/admission.rs
@@ -181,7 +181,7 @@ Rules:
     let v: serde_json::Value = serde_json::from_str(cleaned).with_context(|| {
         format!(
             "LLM risk JSON parse failed: {}",
-            &raw.chars().take(180).collect::<String>()
+            raw.chars().take(180).collect::<String>()
         )
     })?;
     let risk = match v


### PR DESCRIPTION
## Summary
- Rewrite shebang first-line handling in `scan.rs` with `?` to satisfy `clippy::question_mark`.
- Drop redundant `&` in admission LLM parse error `format!` (`clippy::useless_borrows_in_formatting`).
- Unblocks CI `cargo clippy --all-targets -- -D warnings` for `skilllite-commands`.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Confirm CI clippy job is green on this PR


Made with [Cursor](https://cursor.com)