### PR TITLE
docs: note LangChain official catalog listing for SkillLiteTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ skilllite remove <skill-name>               # Remove an installed skill
 
 ### Framework Integration
 
+`langchain-skilllite` is listed in LangChain’s official Python integrations catalog as an **external** tool provider (`SkillLiteTool`). See the [providers catalog](https://docs.langchain.com/oss/python/integrations/providers/all_providers) ([docs PR #5347](https://github.com/langchain-ai/docs/pull/5347)). The package is independently maintained; it is not a LangChain first-party component.
+
 ```bash
 pip install langchain-skilllite   # LangChain adapter
 ```
@@ -493,7 +495,7 @@ skilllite/                         Dependency Flow
 ### SDK & Integrations
 
 - **python-sdk** (`pip install skilllite`) — Thin bridge (~770 lines of Python under `python-sdk/skilllite/`), zero runtime deps
-- **langchain-skilllite** (`pip install langchain-skilllite`) — LangChain / LangGraph adapter
+- **langchain-skilllite** (`pip install langchain-skilllite`) — LangChain / LangGraph adapter; listed in the [LangChain Python integrations catalog](https://docs.langchain.com/oss/python/integrations/providers/all_providers) as an external provider (`SkillLiteTool`, [PR #5347](https://github.com/langchain-ai/docs/pull/5347))
 
 <details>
 <summary>CLI Commands</summary>

--- a/docs/en/ARCHITECTURE.md
+++ b/docs/en/ARCHITECTURE.md
@@ -560,7 +560,7 @@ Separate from `skilllite-agent::rpc` — the latter is dedicated to Agent Chat s
 
 ### 8. LangChain Integration (langchain-skilllite)
 
-> Separate package `pip install langchain-skilllite`; version is defined in `langchain-skilllite/pyproject.toml` (released independently from the main repo `skilllite` PyPI package).
+> Separate package `pip install langchain-skilllite`; version is defined in `langchain-skilllite/pyproject.toml` (released independently from the main repo `skilllite` PyPI package). Listed in LangChain’s official [Python integrations catalog](https://docs.langchain.com/oss/python/integrations/providers/all_providers) as an external `SkillLiteTool` provider ([docs PR #5347](https://github.com/langchain-ai/docs/pull/5347)); not a LangChain first-party component.
 
 | Module | Responsibility |
 |--------|---------------|

--- a/docs/en/GETTING_STARTED.md
+++ b/docs/en/GETTING_STARTED.md
@@ -47,7 +47,7 @@ result = chat("Calculate 15 * 23", skills_dir=".skills")
 print(result)
 ```
 
-For LangChain/LlamaIndex integration, use `langchain-skilllite`:
+For LangChain/LlamaIndex integration, use `langchain-skilllite` (listed in the [LangChain Python integrations catalog](https://docs.langchain.com/oss/python/integrations/providers/all_providers) as an external `SkillLiteTool` provider):
 ```bash
 pip install langchain-skilllite
 ```

--- a/docs/zh/ARCHITECTURE.md
+++ b/docs/zh/ARCHITECTURE.md
@@ -558,7 +558,7 @@ Agent chat 和 Desktop Assistant 在 replan 或重复工具失败后会收到结
 
 ### 8. LangChain 集成 (langchain-skilllite)
 
-> 独立包 `pip install langchain-skilllite`；版本以 `langchain-skilllite/pyproject.toml` 为准（与主仓库 `skilllite` PyPI 包解耦发布）。
+> 独立包 `pip install langchain-skilllite`；版本以 `langchain-skilllite/pyproject.toml` 为准（与主仓库 `skilllite` PyPI 包解耦发布）。已作为外部 `SkillLiteTool` 列入 LangChain 官方 [Python 集成目录](https://docs.langchain.com/oss/python/integrations/providers/all_providers)（[文档 PR #5347](https://github.com/langchain-ai/docs/pull/5347)），不是 LangChain 一等组件。
 
 | 模块 | 职责 |
 |------|------|

--- a/docs/zh/GETTING_STARTED.md
+++ b/docs/zh/GETTING_STARTED.md
@@ -47,7 +47,7 @@ result = chat("计算 15 乘以 23", skills_dir=".skills")
 print(result)
 ```
 
-LangChain/LlamaIndex 集成请使用 `langchain-skilllite`：
+LangChain/LlamaIndex 集成请使用 `langchain-skilllite`（已作为外部 `SkillLiteTool` 列入 [LangChain Python 集成目录](https://docs.langchain.com/oss/python/integrations/providers/all_providers)）：
 ```bash
 pip install langchain-skilllite
 ```

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -323,6 +323,8 @@ skilllite remove <skill-name>               # 移除已安装的 skill
 
 ### 框架集成
 
+`langchain-skilllite` 已收录进 LangChain 官方 Python 集成目录，作为**外部** Tool 提供方（`SkillLiteTool`）。见 [providers 目录](https://docs.langchain.com/oss/python/integrations/providers/all_providers)（[文档 PR #5347](https://github.com/langchain-ai/docs/pull/5347)）。包由本项目独立维护，不是 LangChain 一等组件。
+
 ```bash
 pip install langchain-skilllite   # LangChain 适配器
 ```
@@ -445,7 +447,7 @@ skilllite/                         依赖流向
 ### SDK 与集成
 
 - **python-sdk**（`pip install skilllite`）— 薄桥接层，零 PyPI 运行时依赖；含 `artifact_put` / `artifact_get`（HTTP，标准库）与二进制桥接 API
-- **langchain-skilllite**（`pip install langchain-skilllite`）— LangChain / LangGraph 适配器
+- **langchain-skilllite**（`pip install langchain-skilllite`）— LangChain / LangGraph 适配器；已作为外部提供方（`SkillLiteTool`）列入 [LangChain Python 集成目录](https://docs.langchain.com/oss/python/integrations/providers/all_providers)（[PR #5347](https://github.com/langchain-ai/docs/pull/5347)）
 
 <details>
 <summary>CLI 命令</summary>

--- a/tutorials/04_langchain_integration/README.md
+++ b/tutorials/04_langchain_integration/README.md
@@ -2,6 +2,8 @@
 
 SkillLite provides LangChain integration through the [langchain-skilllite](https://pypi.org/project/langchain-skilllite/) package.
 
+LangChain’s official Python integrations catalog lists SkillLite as an **external** tool provider (`SkillLiteTool`): [providers catalog](https://docs.langchain.com/oss/python/integrations/providers/all_providers) ([docs PR #5347](https://github.com/langchain-ai/docs/pull/5347)). The adapter remains independently maintained.
+
 ## Prerequisites
 
 ```bash

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -79,6 +79,9 @@ print(result["text"])
 ```
 
 ### LangChain Integration
+
+Listed in LangChain’s official [Python integrations catalog](https://docs.langchain.com/oss/python/integrations/providers/all_providers) as an external `SkillLiteTool` provider.
+
 ```bash
 pip install langchain-skilllite
 ```


### PR DESCRIPTION
## Summary
- Document that `langchain-skilllite` is listed in LangChain’s official Python integrations catalog as an **external** `SkillLiteTool` provider.
- Link the [providers catalog](https://docs.langchain.com/oss/python/integrations/providers/all_providers) and [langchain-ai/docs#5347](https://github.com/langchain-ai/docs/pull/5347).
- Keep EN/ZH wording aligned and avoid implying first-party ownership.

## Test plan
- [ ] Spot-check README / Getting Started / Architecture / tutorial links
- [ ] Confirm catalog and PR URLs resolve


Made with [Cursor](https://cursor.com)